### PR TITLE
Fix TFTP buffer size

### DIFF
--- a/netboot.c
+++ b/netboot.c
@@ -353,11 +353,9 @@ EFI_STATUS FetchNetbootimage(EFI_HANDLE image_handle, VOID **buffer, UINTN *bufs
 
 try_again:
 	rc = uefi_call_wrapper(pxe->Mtftp, 10, pxe, read, *buffer, overwrite,
-				&bufsiz, &blksz, &tftp_addr, full_path, NULL, nobuffer);
+				bufsiz, &blksz, &tftp_addr, full_path, NULL, nobuffer);
 
 	if (rc == EFI_BUFFER_TOO_SMALL) {
-		/* try again, doubling buf size */
-		*bufsiz *= 2;
 		FreePool(*buffer);
 		*buffer = AllocatePool(*bufsiz);
 		if (!*buffer)


### PR DESCRIPTION
Currently shim can't boot with PXE. It fails with

```
Fetching Netboot image
Invalid signature
Verification failed
```

Because bufsiz needs to be the exact file size but now the hashes are calculated on the default 4MB buffer, and thus, wrong.

&bufsiz was a typo.

"For read-file operations, if `EFI_BUFFER_TOO_SMALL` is returned, `*BufferSize` returns the size of the requested file."

So just use it.

Signed-off-by: Lingzhu Xiang lxiang@redhat.com
