### PR TITLE
Pass the right arguments to EFI_PXE_BASE_CODE_TFTP_READ_FILE

### DIFF
--- a/netboot.c
+++ b/netboot.c
@@ -326,7 +326,7 @@ EFI_STATUS parseNetbootinfo(EFI_HANDLE image_handle)
 	return rc;
 }
 
-EFI_STATUS FetchNetbootimage(EFI_HANDLE image_handle, VOID **buffer, UINTN *bufsiz)
+EFI_STATUS FetchNetbootimage(EFI_HANDLE image_handle, VOID **buffer, UINT64 *bufsiz)
 {
 	EFI_STATUS rc;
 	EFI_PXE_BASE_CODE_TFTP_OPCODE read = EFI_PXE_BASE_CODE_TFTP_READ_FILE;
@@ -344,7 +344,7 @@ EFI_STATUS FetchNetbootimage(EFI_HANDLE image_handle, VOID **buffer, UINTN *bufs
 
 try_again:
 	rc = uefi_call_wrapper(pxe->Mtftp, 10, pxe, read, *buffer, overwrite,
-				&bufsiz, &blksz, &tftp_addr, full_path, NULL, nobuffer);
+				bufsiz, &blksz, &tftp_addr, full_path, NULL, nobuffer);
 
 	if (rc == EFI_BUFFER_TOO_SMALL) {
 		/* try again, doubling buf size */

--- a/shim.c
+++ b/shim.c
@@ -1179,7 +1179,7 @@ EFI_STATUS start_image(EFI_HANDLE image_handle, CHAR16 *ImagePath)
 	EFI_DEVICE_PATH *path;
 	CHAR16 *PathName = NULL;
 	void *sourcebuffer = NULL;
-	UINTN sourcesize = 0;
+	UINT64 sourcesize = 0;
 	void *data = NULL;
 	int datasize;
 


### PR DESCRIPTION
A wrong pointer was being passed to EFI_PXE_BASE_CODE_TFTP_READ_FILE,
preventing us from getting the file size back from the tftp call, ensuring
that we don't have enough information to properly secureboot-validate the
retrieved image.
