### PR TITLE
Exclude ca.crt while signing EFI images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,6 @@ version.c : version.c.in
 
 certdb/secmod.db: shim.crt
 	-mkdir certdb
-	certutil -A -n 'my CA' -d certdb/ -t CT,CT,CT -i ca.crt
 	pk12util -d certdb/ -i shim.p12 -W "" -K ""
 	certutil -d certdb/ -A -i shim.crt -n shim -t u
 


### PR DESCRIPTION
If ca.crt was added into the certificate database, ca.crt would be the first
certificate in the signature. Because shim couldn't verify ca.crt with the
embedded shim.cer, it failed to load MokManager.efi.signed and
fallback.efi.signed.

Signed-off-by: Gary Ching-Pang Lin glin@suse.com
