### PR TITLE
Fix detection of SetupMode in secure_mode

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -472,17 +472,14 @@ static BOOLEAN secure_mode (void)
 
 	status = get_variable(L"SetupMode", &Data, &len, global_var);
 	if (status == EFI_SUCCESS) {
-		if (verbose)
-			console_notify(L"Platform is in setup mode\n");
-		return FALSE;
-	}
-	setupmode = *Data;
-	FreePool(Data);
+		setupmode = *Data;
+		FreePool(Data);
 
-	if (setupmode == 1) {
-		if (verbose)
-			console_notify(L"Platform is in setup mode\n");
-		return FALSE;
+		if (setupmode == 1) {
+			if (verbose)
+				console_notify(L"Platform is in setup mode\n");
+			return FALSE;
+		}
 	}
 
 	return TRUE;


### PR DESCRIPTION
This was broken by commit 556c445ea19fc257fe35ac1a67477e7352ba3fcd. The
previous code assumes setup mode even if just the SetupMode variable is
present but not set to 1. If get_variable returns EFI_SUCCESS, this only
means that the variable was read successfully and does not tell anything
about it's value. And as we already checked if secure boot is enabled, the
function should return TRUE anyway.

This is a security fix as in setup mode shim will load unsigned code!

@vathpela: please check this commit, it fixes something you broke some days ago.
