### PR TITLE
MokManager: handle the error status from ReadKeyStroke

### DIFF
--- a/MokManager.c
+++ b/MokManager.c
@@ -488,13 +488,19 @@ static EFI_STATUS list_keys (void *KeyList, UINTN KeyListSize, CHAR16 *title)
 	return EFI_SUCCESS;
 }
 
-static UINT8 get_line (UINT32 *length, CHAR16 *line, UINT32 line_max, UINT8 show)
+static EFI_STATUS get_line (UINT32 *length, CHAR16 *line, UINT32 line_max, UINT8 show)
 {
 	EFI_INPUT_KEY key;
+	EFI_STATUS status;
 	int count = 0;
 
 	do {
-		key = console_get_keystroke();
+		status = console_get_keystroke(&key);
+		if (EFI_ERROR (status)) {
+			console_error(L"Failed to read the keystroke", status);
+			*length = 0;
+			return status;
+		}
 
 		if ((count >= line_max &&
 		     key.UnicodeChar != CHAR_BACKSPACE) ||
@@ -525,7 +531,7 @@ static UINT8 get_line (UINT32 *length, CHAR16 *line, UINT32 line_max, UINT8 show
 
 	*length = count;
 
-	return 1;
+	return EFI_SUCCESS;
 }
 
 static EFI_STATUS compute_pw_hash (void *Data, UINTN DataSize, UINT8 *password,
@@ -989,6 +995,7 @@ static INTN mok_deletion_prompt (void *MokDel, UINTN MokDelSize)
 static CHAR16 get_password_charater (CHAR16 *prompt)
 {
 	SIMPLE_TEXT_OUTPUT_MODE SavedMode;
+	EFI_STATUS status;
 	CHAR16 *message[2];
 	CHAR16 character;
 	UINTN length;
@@ -1003,7 +1010,9 @@ static CHAR16 get_password_charater (CHAR16 *prompt)
 	message[1] = NULL;
 	length = StrLen(message[0]);
 	console_print_box_at(message, -1, -length-4, -5, length+4, 3, 0, 1);
-	get_line(&pw_length, &character, 1, 0);
+	status = get_line(&pw_length, &character, 1, 0);
+	if (EFI_ERROR(status))
+		character = 0;
 
 	console_restore_mode(&SavedMode);
 

--- a/include/console.h
+++ b/include/console.h
@@ -1,8 +1,8 @@
 #ifndef _SHIM_LIB_CONSOLE_H
 #define _SHIM_LIB_CONSOLE_H 1
 
-EFI_INPUT_KEY
-console_get_keystroke(void);
+EFI_STATUS
+console_get_keystroke(EFI_INPUT_KEY *key);
 void
 console_print_box_at(CHAR16 *str_arr[], int highlight, int start_col, int start_row, int size_cols, int size_rows, int offset, int lines);
 void

--- a/lib/console.c
+++ b/lib/console.c
@@ -40,16 +40,18 @@ SetMem16(CHAR16 *dst, UINT32 n, CHAR16 c)
 	}
 }
 
-EFI_INPUT_KEY
-console_get_keystroke(void)
+EFI_STATUS
+console_get_keystroke(EFI_INPUT_KEY *key)
 {
-	EFI_INPUT_KEY key;
 	UINTN EventIndex;
+	EFI_STATUS status;
 
-	uefi_call_wrapper(BS->WaitForEvent, 3, 1, &ST->ConIn->WaitForKey, &EventIndex);
-	uefi_call_wrapper(ST->ConIn->ReadKeyStroke, 2, ST->ConIn, &key);
+	do {
+		uefi_call_wrapper(BS->WaitForEvent, 3, 1, &ST->ConIn->WaitForKey, &EventIndex);
+		status = uefi_call_wrapper(ST->ConIn->ReadKeyStroke, 2, ST->ConIn, key);
+	} while (status == EFI_NOT_READY);
 
-	return key;
+	return status;
 }
 
 void
@@ -162,6 +164,8 @@ console_print_box(CHAR16 *str_arr[], int highlight)
 {
 	SIMPLE_TEXT_OUTPUT_MODE SavedConsoleMode;
 	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
+	EFI_INPUT_KEY key;
+
 	CopyMem(&SavedConsoleMode, co->Mode, sizeof(SavedConsoleMode));
 	uefi_call_wrapper(co->EnableCursor, 2, co, FALSE);
 	uefi_call_wrapper(co->SetAttribute, 2, co, EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE);
@@ -169,7 +173,7 @@ console_print_box(CHAR16 *str_arr[], int highlight)
 	console_print_box_at(str_arr, highlight, 0, 0, -1, -1, 0,
 			     count_lines(str_arr));
 
-	console_get_keystroke();
+	console_get_keystroke(&key);
 
 	uefi_call_wrapper(co->EnableCursor, 2, co, SavedConsoleMode.CursorVisible);
 
@@ -184,6 +188,7 @@ console_select(CHAR16 *title[], CHAR16* selectors[], int start)
 	SIMPLE_TEXT_OUTPUT_MODE SavedConsoleMode;
 	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
 	EFI_INPUT_KEY k;
+	EFI_STATUS status;
 	int selector;
 	int selector_lines = count_lines(selectors);
 	int selector_max_cols = 0;
@@ -237,7 +242,12 @@ console_select(CHAR16 *title[], CHAR16* selectors[], int start)
 			     size_cols, size_rows, 0, lines);
 
 	do {
-		k = console_get_keystroke();
+		status = console_get_keystroke(&k);
+		if (EFI_ERROR (status)) {
+			Print(L"Failed to read the keystroke: %r", status);
+			selector = -1;
+			break;
+		}
 
 		if (k.ScanCode == SCAN_ESC) {
 			selector = -1;


### PR DESCRIPTION
On some machines, even though the key event was signaled, ReadKeyStroke
still got EFI_NOT_READY. This commit handles the error status to avoid
console_get_keystroke from returning unexpected keys.

Signed-off-by: Gary Ching-Pang Lin glin@suse.com
