### PR TITLE
Don't verify images with the empty build key

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -915,7 +915,8 @@ static EFI_STATUS verify_buffer (char *data, int datasize,
 		/*
 		 * Check against the shim build key
 		 */
-		if (AuthenticodeVerify(cert->CertData,
+		if (sizeof(shim_cert) &&
+		    AuthenticodeVerify(cert->CertData,
 			       context->SecDir->Size - sizeof(cert->Hdr),
 			       shim_cert, sizeof(shim_cert), sha256hash,
 			       SHA256_DIGEST_SIZE)) {


### PR DESCRIPTION
We replaced the build key with an empty file while compiling shim
for our distro. Skip the verification with the empty build key
since this makes no sense.

Signed-off-by: Gary Ching-Pang Lin glin@suse.com
