### PR TITLE
httpboot: fix OVMF crash

### DIFF
--- a/httpboot.c
+++ b/httpboot.c
@@ -110,8 +110,10 @@ find_httpboot (EFI_HANDLE device)
 	URI_DEVICE_PATH *UriNode;
 	UINTN uri_size;
 
-	if (!uri)
+	if (uri) {
 		FreePool(uri);
+		uri = NULL;
+	}
 
 	devpath = DevicePathFromHandle(device);
 	if (!devpath) {


### PR DESCRIPTION
This is a typical typo. The free operation should be done if uri
was allocated.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>