### PR TITLE
Add spec-based PCR7 support

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -962,10 +962,9 @@ static EFI_STATUS verify_mok (void) {
  * Check that the signature is valid and matches the binary
  */
 static EFI_STATUS verify_buffer (char *data, int datasize,
-			 PE_COFF_LOADER_IMAGE_CONTEXT *context)
+				 PE_COFF_LOADER_IMAGE_CONTEXT *context,
+				 UINT8 *sha256hash, UINT8 *sha1hash)
 {
-	UINT8 sha256hash[SHA256_DIGEST_SIZE];
-	UINT8 sha1hash[SHA1_DIGEST_SIZE];
 	EFI_STATUS status = EFI_SECURITY_VIOLATION;
 	WIN_CERTIFICATE_EFI_PKCS *cert = NULL;
 	unsigned int size = datasize;
@@ -1206,6 +1205,8 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 	unsigned int alignment, alloc_size;
 	EFI_PHYSICAL_ADDRESS alloc_address;
 	int found_entry_point = 0;
+	UINT8 sha1hash[SHA1_DIGEST_SIZE];
+	UINT8 sha256hash[SHA256_DIGEST_SIZE];
 
 	/*
 	 * The binary header contains relevant context and section pointers
@@ -1219,8 +1220,17 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 	/*
 	 * We only need to verify the binary if we're in secure mode
 	 */
+	efi_status = generate_hash(data, datasize, &context, sha256hash,
+				   sha1hash);
+	if (efi_status != EFI_SUCCESS)
+		return efi_status;
+
+	/* Measure the binary into the TPM */
+	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, sha1hash, 9);
+
 	if (secure_mode ()) {
-		efi_status = verify_buffer(data, datasize, &context);
+		efi_status = verify_buffer(data, datasize, &context,
+					   sha256hash, sha1hash);
 
 		if (EFI_ERROR(efi_status)) {
 			console_error(L"Verification failed", efi_status);
@@ -1711,6 +1721,8 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 {
 	EFI_STATUS status = EFI_SUCCESS;
 	PE_COFF_LOADER_IMAGE_CONTEXT context;
+	UINT8 sha1hash[SHA1_DIGEST_SIZE];
+	UINT8 sha256hash[SHA256_DIGEST_SIZE];
 
 	loader_is_participating = 1;
 	in_protocol = 1;
@@ -1722,7 +1734,11 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 	if (status != EFI_SUCCESS)
 		goto done;
 
-	status = verify_buffer(buffer, size, &context);
+	status = generate_hash(buffer, size, &context, sha256hash, sha1hash);
+	if (status != EFI_SUCCESS)
+		goto done;
+
+	status = verify_buffer(buffer, size, &context, sha256hash, sha1hash);
 done:
 	in_protocol = 0;
 	return status;
@@ -1825,10 +1841,6 @@ EFI_STATUS start_image(EFI_HANDLE image_handle, CHAR16 *ImagePath)
 			goto done;
 		}
 	}
-
-	/* Measure the binary into the TPM */
-	tpm_log_event((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize,
-		      9, (CHAR8 *)"Second stage bootloader");
 
 	/*
 	 * We need to modify the loaded image protocol entry before running

--- a/shim.c
+++ b/shim.c
@@ -428,7 +428,8 @@ static BOOLEAN verify_eku(UINT8 *Cert, UINTN CertSize)
 static CHECK_STATUS check_db_cert_in_ram(EFI_SIGNATURE_LIST *CertList,
 					 UINTN dbsize,
 					 WIN_CERTIFICATE_EFI_PKCS *data,
-					 UINT8 *hash)
+					 UINT8 *hash, CHAR16 *dbname,
+					 EFI_GUID guid)
 {
 	EFI_SIGNATURE_DATA *Cert;
 	UINTN CertSize;
@@ -446,8 +447,10 @@ static CHECK_STATUS check_db_cert_in_ram(EFI_SIGNATURE_LIST *CertList,
 								      Cert->SignatureData,
 								      CertSize,
 								      hash, SHA256_DIGEST_SIZE);
-					if (IsFound)
+					if (IsFound) {
+						tpm_measure_variable(dbname, guid, CertSize, Cert->SignatureData);
 						return DATA_FOUND;
+					}
 				}
 			} else if (verbose) {
 				console_notify(L"Not a DER encoding x.509 Certificate");
@@ -477,7 +480,7 @@ static CHECK_STATUS check_db_cert(CHAR16 *dbname, EFI_GUID guid,
 
 	CertList = (EFI_SIGNATURE_LIST *)db;
 
-	rc = check_db_cert_in_ram(CertList, dbsize, data, hash);
+	rc = check_db_cert_in_ram(CertList, dbsize, data, hash, dbname, guid);
 
 	FreePool(db);
 
@@ -489,7 +492,8 @@ static CHECK_STATUS check_db_cert(CHAR16 *dbname, EFI_GUID guid,
  */
 static CHECK_STATUS check_db_hash_in_ram(EFI_SIGNATURE_LIST *CertList,
 					 UINTN dbsize, UINT8 *data,
-					 int SignatureSize, EFI_GUID CertType)
+					 int SignatureSize, EFI_GUID CertType,
+					 CHAR16 *dbname, EFI_GUID guid)
 {
 	EFI_SIGNATURE_DATA *Cert;
 	UINTN CertCount, Index;
@@ -505,6 +509,7 @@ static CHECK_STATUS check_db_hash_in_ram(EFI_SIGNATURE_LIST *CertList,
 					// Find the signature in database.
 					//
 					IsFound = TRUE;
+					tpm_measure_variable(dbname, guid, SignatureSize, data);
 					break;
 				}
 
@@ -545,7 +550,8 @@ static CHECK_STATUS check_db_hash(CHAR16 *dbname, EFI_GUID guid, UINT8 *data,
 	CertList = (EFI_SIGNATURE_LIST *)db;
 
 	CHECK_STATUS rc = check_db_hash_in_ram(CertList, dbsize, data,
-						SignatureSize, CertType);
+					       SignatureSize, CertType,
+					       dbname, guid);
 	FreePool(db);
 	return rc;
 
@@ -563,15 +569,18 @@ static EFI_STATUS check_blacklist (WIN_CERTIFICATE_EFI_PKCS *cert,
 	EFI_SIGNATURE_LIST *dbx = (EFI_SIGNATURE_LIST *)vendor_dbx;
 
 	if (check_db_hash_in_ram(dbx, vendor_dbx_size, sha256hash,
-				 SHA256_DIGEST_SIZE, EFI_CERT_SHA256_GUID) ==
+				 SHA256_DIGEST_SIZE, EFI_CERT_SHA256_GUID,
+				 L"dbx", secure_var) ==
 				DATA_FOUND)
 		return EFI_SECURITY_VIOLATION;
 	if (check_db_hash_in_ram(dbx, vendor_dbx_size, sha1hash,
-				 SHA1_DIGEST_SIZE, EFI_CERT_SHA1_GUID) ==
+				 SHA1_DIGEST_SIZE, EFI_CERT_SHA1_GUID,
+				 L"dbx", secure_var) ==
 				DATA_FOUND)
 		return EFI_SECURITY_VIOLATION;
 	if (cert && check_db_cert_in_ram(dbx, vendor_dbx_size, cert,
-					 sha256hash) == DATA_FOUND)
+					 sha256hash, L"dbx",
+					 secure_var) == DATA_FOUND)
 		return EFI_SECURITY_VIOLATION;
 
 	if (check_db_hash(L"dbx", secure_var, sha256hash, SHA256_DIGEST_SIZE,
@@ -960,6 +969,7 @@ static EFI_STATUS verify_buffer (char *data, int datasize,
 	EFI_STATUS status = EFI_SECURITY_VIOLATION;
 	WIN_CERTIFICATE_EFI_PKCS *cert = NULL;
 	unsigned int size = datasize;
+	EFI_GUID shim_var = SHIM_LOCK_GUID;
 
 	if (context->SecDir->Size != 0) {
 		if (context->SecDir->Size >= size) {
@@ -1026,6 +1036,7 @@ static EFI_STATUS verify_buffer (char *data, int datasize,
 			       shim_cert, sizeof(shim_cert), sha256hash,
 			       SHA256_DIGEST_SIZE)) {
 			update_verification_method(VERIFIED_BY_CERT);
+			tpm_measure_variable(L"Shim", shim_var, sizeof(shim_cert), shim_cert);
 			status = EFI_SUCCESS;
 			return status;
 		}
@@ -1039,6 +1050,7 @@ static EFI_STATUS verify_buffer (char *data, int datasize,
 				       vendor_cert, vendor_cert_size,
 				       sha256hash, SHA256_DIGEST_SIZE)) {
 			update_verification_method(VERIFIED_BY_CERT);
+			tpm_measure_variable(L"Shim", shim_var, vendor_cert_size, vendor_cert);
 			status = EFI_SUCCESS;
 			return status;
 		}
@@ -1888,7 +1900,11 @@ EFI_STATUS init_grub(EFI_HANDLE image_handle)
 }
 
 /*
- * Measure some of the MOK variables into the TPM
+ * Measure some of the MOK variables into the TPM. We measure the entirety
+ * of MokList into PCR 14, and also measure the raw MokSBState there. PCR 7
+ * will be extended with MokSBState in the Microsoft format, and we'll
+ * measure any matching hashes or certificates later on in order to behave
+ * consistently with the PCR 7 spec.
  */
 EFI_STATUS measure_mok()
 {
@@ -1915,9 +1931,14 @@ EFI_STATUS measure_mok()
 	if (efi_status != EFI_SUCCESS)
 		return efi_status;
 
+	efi_status = tpm_measure_variable(L"MokSBState", shim_lock_guid,
+					  DataSize, Data);
+	if (efi_status != EFI_SUCCESS)
+		goto out;
+
 	efi_status = tpm_log_event((EFI_PHYSICAL_ADDRESS)(UINTN)Data,
 				   DataSize, 14, (CHAR8 *)"MokSBState");
-
+out:
 	FreePool(Data);
 
 	return efi_status;

--- a/tpm.c
+++ b/tpm.c
@@ -121,7 +121,7 @@ static EFI_STATUS trigger_tcg2_final_events_table(efi_tpm2_protocol_t *tpm2,
 
 static EFI_STATUS tpm_log_event_raw(EFI_PHYSICAL_ADDRESS buf, UINTN size,
 				    UINT8 pcr, const CHAR8 *log, UINTN logsize,
-				    UINT32 type)
+				    UINT32 type, CHAR8 *hash)
 {
 	EFI_STATUS status;
 	efi_tpm_protocol_t *tpm;
@@ -162,8 +162,18 @@ static EFI_STATUS tpm_log_event_raw(EFI_PHYSICAL_ADDRESS buf, UINTN size,
 		event->Header.EventType = type;
 		event->Size = sizeof(*event) - sizeof(event->Event) + logsize + 1;
 		CopyMem(event->Event, (VOID *)log, logsize);
-		status = uefi_call_wrapper(tpm2->hash_log_extend_event, 5, tpm2,
-					   0, buf, (UINT64) size, event);
+		if (hash) {
+			/* TPM 2 systems will generate the appropriate hash
+			   themselves if we pass PE_COFF_IMAGE
+			*/
+			status = uefi_call_wrapper(tpm2->hash_log_extend_event,
+						   5, tpm2, PE_COFF_IMAGE, buf,
+						   (UINT64) size, event);
+		} else {
+			status = uefi_call_wrapper(tpm2->hash_log_extend_event,
+						   5, tpm2, 0, buf,
+						   (UINT64) size, event);
+		}
 		FreePool(event);
 		return status;
 	} else {
@@ -190,9 +200,21 @@ static EFI_STATUS tpm_log_event_raw(EFI_PHYSICAL_ADDRESS buf, UINTN size,
 		event->EventType = type;
 		event->EventSize = logsize;
 		CopyMem(event->Event, (VOID *)log, logsize);
-		status = uefi_call_wrapper(tpm->log_extend_event, 7, tpm, buf,
-					   (UINT64)size, TPM_ALG_SHA, event,
-					   &eventnum, &lastevent);
+		if (hash) {
+			/* TPM 1.2 devices require us to pass the Authenticode
+			   hash rather than allowing the firmware to attempt
+			   to calculate it */
+			CopyMem(event->digest, hash, sizeof(event->digest));
+			status = uefi_call_wrapper(tpm->log_extend_event, 7,
+						   tpm, 0, 0, TPM_ALG_SHA,
+						   event, &eventnum,
+						   &lastevent);
+		} else {
+			status = uefi_call_wrapper(tpm->log_extend_event, 7,
+						   tpm, buf, (UINT64)size,
+						   TPM_ALG_SHA, event,
+						   &eventnum, &lastevent);
+		}
 		FreePool(event);
 		return status;
 	}
@@ -203,7 +225,24 @@ EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,
 			 const CHAR8 *description)
 {
 	return tpm_log_event_raw(buf, size, pcr, description,
-				 strlen(description) + 1, 0xd);
+				 strlen(description) + 1, 0xd, NULL);
+}
+
+EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 *sha1hash,
+		      UINT8 pcr)
+{
+	EFI_IMAGE_LOAD_EVENT ImageLoad;
+
+	// All of this is informational and forces us to do more parsing before
+	// we can generate it, so let's just leave it out for now
+	ImageLoad.ImageLocationInMemory = 0;
+	ImageLoad.ImageLengthInMemory = 0;
+	ImageLoad.ImageLinkTimeAddress = 0;
+	ImageLoad.LengthOfDevicePath = 0;
+
+	return tpm_log_event_raw(buf, size, pcr, (CHAR8 *)&ImageLoad,
+				 sizeof(ImageLoad),
+				 EV_EFI_BOOT_SERVICES_APPLICATION, sha1hash);
 }
 
 typedef struct {
@@ -295,7 +334,7 @@ EFI_STATUS tpm_measure_variable(CHAR16 *VarName, EFI_GUID VendorGuid, UINTN VarS
 
 	Status = tpm_log_event_raw((EFI_PHYSICAL_ADDRESS)VarLog, VarLogSize, 7,
 				   (CHAR8 *)VarLog, VarLogSize,
-				   EV_EFI_VARIABLE_AUTHORITY);
+				   EV_EFI_VARIABLE_AUTHORITY, NULL);
 
 	FreePool(VarLog);
 

--- a/tpm.h
+++ b/tpm.h
@@ -1,3 +1,5 @@
+#include <efilib.h>
+
 #define EFI_TPM_GUID {0xf541796d, 0xa62e, 0x4954, {0xa7, 0x75, 0x95, 0x84, 0xf6, 0x1b, 0x9c, 0xdd }};
 #define EFI_TPM2_GUID {0x607f766c, 0x7455, 0x42be, {0x93, 0x0b, 0xe4, 0xd7, 0x6d, 0xb2, 0x72, 0x0f }};
 
@@ -6,6 +8,9 @@
 
 EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,
 			 const CHAR8 *description);
+
+EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 *sha1hash,
+		      UINT8 pcr);
 
 EFI_STATUS tpm_measure_variable(CHAR16 *dbname, EFI_GUID guid, UINTN size, void *data);
 
@@ -32,6 +37,14 @@ typedef struct _TCG_PCR_EVENT {
   uint32_t EventSize;
   uint8_t  Event[1];
 } TCG_PCR_EVENT;
+
+typedef struct _EFI_IMAGE_LOAD_EVENT {
+  EFI_PHYSICAL_ADDRESS ImageLocationInMemory;
+  UINTN ImageLengthInMemory;
+  UINTN ImageLinkTimeAddress;
+  UINTN LengthOfDevicePath;
+  EFI_DEVICE_PATH DevicePath[1];
+} EFI_IMAGE_LOAD_EVENT;
 
 struct efi_tpm_protocol
 {
@@ -170,3 +183,5 @@ typedef UINT32                     TCG_EVENTTYPE;
 #define EV_EFI_PLATFORM_FIRMWARE_BLOB       (EV_EFI_EVENT_BASE + 8)
 #define EV_EFI_HANDOFF_TABLES               (EV_EFI_EVENT_BASE + 9)
 #define EV_EFI_VARIABLE_AUTHORITY           (EV_EFI_EVENT_BASE + 0xE0)
+
+#define PE_COFF_IMAGE 0x0000000000000010

--- a/tpm.h
+++ b/tpm.h
@@ -7,6 +7,8 @@
 EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,
 			 const CHAR8 *description);
 
+EFI_STATUS tpm_measure_variable(CHAR16 *dbname, EFI_GUID guid, UINTN size, void *data);
+
 typedef struct {
   uint8_t Major;
   uint8_t Minor;
@@ -154,3 +156,17 @@ struct efi_tpm2_protocol
 };
 
 typedef struct efi_tpm2_protocol efi_tpm2_protocol_t;
+
+typedef UINT32                     TCG_EVENTTYPE;
+
+#define EV_EFI_EVENT_BASE                   ((TCG_EVENTTYPE) 0x80000000)
+#define EV_EFI_VARIABLE_DRIVER_CONFIG       (EV_EFI_EVENT_BASE + 1)
+#define EV_EFI_VARIABLE_BOOT                (EV_EFI_EVENT_BASE + 2)
+#define EV_EFI_BOOT_SERVICES_APPLICATION    (EV_EFI_EVENT_BASE + 3)
+#define EV_EFI_BOOT_SERVICES_DRIVER         (EV_EFI_EVENT_BASE + 4)
+#define EV_EFI_RUNTIME_SERVICES_DRIVER      (EV_EFI_EVENT_BASE + 5)
+#define EV_EFI_GPT_EVENT                    (EV_EFI_EVENT_BASE + 6)
+#define EV_EFI_ACTION                       (EV_EFI_EVENT_BASE + 7)
+#define EV_EFI_PLATFORM_FIRMWARE_BLOB       (EV_EFI_EVENT_BASE + 8)
+#define EV_EFI_HANDOFF_TABLES               (EV_EFI_EVENT_BASE + 9)
+#define EV_EFI_VARIABLE_AUTHORITY           (EV_EFI_EVENT_BASE + 0xE0)


### PR DESCRIPTION
Add support for measuring the Shim signing state into PCR7 in the same way that the firmware does in Secure Boot mode.