### PR TITLE
README.fallback: correct the path of BOOT.CSV in layout example

### DIFF
--- a/README.fallback
+++ b/README.fallback
@@ -24,7 +24,7 @@ for an installed system:
 \EFI\BOOT\BOOTX64.EFI    <-- shim
 \EFI\BOOT\MokManager.efi
 \EFI\BOOT\fallback.efi
-\EFI\BOOT\BOOT.CSV
+\EFI\fedora\BOOT.CSV
 \EFI\fedora\shim.efi
 \EFI\fedora\MokManager.efi
 \EFI\fedora\grubx64.efi


### PR DESCRIPTION
BOOT.CSV should be placed in fedora directory in order to locate the base
directory of files recorded in $FILENAME column.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>