### PR TITLE
Make it possible to build in a subdirectory.

### DIFF
--- a/Cryptlib/Makefile
+++ b/Cryptlib/Makefile
@@ -1,7 +1,7 @@
 
-EFI_INCLUDES	= -IInclude -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol
+EFI_INCLUDES	= -I$(TOPDIR)/Include -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol
 
-CFLAGS		= -ggdb -O0 -I. -fno-stack-protector -fno-strict-aliasing -fpic -fshort-wchar \
+CFLAGS		= -ggdb -O0 -I$(TOPDIR) -iquote $(TOPDIR) -fno-stack-protector -fno-strict-aliasing -fpic -fshort-wchar \
 		  -Wall $(EFI_INCLUDES) -std=gnu89 \
 		  -ffreestanding -I$(shell $(CC) -print-file-name=include)
 

--- a/Cryptlib/OpenSSL/Makefile
+++ b/Cryptlib/OpenSSL/Makefile
@@ -1,7 +1,10 @@
 
-EFI_INCLUDES	= -I../Include -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol -Icrypto/asn1 -Icrypto/evp -Icrypto/modes -Icrypto/include
+EFI_INCLUDES	= -I$(TOPDIR)/../Include \
+		  -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol \
+		  -I$(TOPDIR)/crypto/asn1 -I$(TOPDIR)/crypto/evp -I$(TOPDIR)/crypto/modes -I$(TOPDIR)/crypto/include
 
-CFLAGS		= -ggdb -O0 -I. -I.. -I../Include/ -Icrypto -fno-stack-protector -fno-strict-aliasing -fpic -fshort-wchar -nostdinc \
+CFLAGS		= -ggdb -O0 -I$(TOPDIR) -I$(TOPDIR)/.. -I$(TOPDIR)/../Include/ -I$(TOPDIR)/crypto \
+		  -fno-stack-protector -fno-strict-aliasing -fpic -fshort-wchar -nostdinc \
 		  -ffreestanding -std=gnu89 -I$(shell $(CC) -print-file-name=include) \
 		  -Wall $(EFI_INCLUDES) -DL_ENDIAN -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -DNO_SYSLOG -DOPENSSL_SMALL_FOOTPRINT -DPEDANTIC
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,13 @@ ifneq ($(RELEASE),"")
 	RELEASE:="-$(RELEASE)"
 endif
 
+ifeq ($(MAKELEVEL),0)
+TOPDIR		?= $(shell pwd)
+endif
+override TOPDIR	:= $(abspath $(TOPDIR))
+VPATH		= $(TOPDIR)
+
+
 CC		= $(CROSS_COMPILE)gcc
 LD		= $(CROSS_COMPILE)ld
 OBJCOPY		= $(CROSS_COMPILE)objcopy
@@ -16,16 +23,18 @@ PESIGN		?= pesign
 ARCH		?= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
 OBJCOPY_GTE224  = $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.*\((.*)\|version\) //g' | cut -f1-2 -d.` \>= 2.24)
 
-SUBDIRS		= Cryptlib lib
+SUBDIRS		= $(TOPDIR)/Cryptlib $(TOPDIR)/lib
 
 EFI_INCLUDE	:= /usr/include/efi
-EFI_INCLUDES	= -nostdinc -ICryptlib -ICryptlib/Include -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol -I$(shell pwd)/include
+EFI_INCLUDES	= -nostdinc -I$(TOPDIR)/Cryptlib -I$(TOPDIR)/Cryptlib/Include \
+		  -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol \
+		  -I$(TOPDIR)/include -iquote $(TOPDIR) -iquote $(shell pwd)
 
 LIB_GCC		= $(shell $(CC) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC) 
 
 EFI_CRT_OBJS 	= $(EFI_PATH)/crt0-efi-$(ARCH).o
-EFI_LDS		= elf_$(ARCH)_efi.lds
+EFI_LDS		= $(TOPDIR)/elf_$(ARCH)_efi.lds
 
 DEFAULT_LOADER	:= \\\\grub.efi
 CFLAGS		= -ggdb -O0 -fno-stack-protector -fno-strict-aliasing -fpic \
@@ -96,21 +105,25 @@ LDFLAGS		= --hash-style=sysv -nostdlib -znocombreloc -T $(EFI_LDS) -shared -Bsym
 TARGET	= $(SHIMNAME).efi $(MMNAME).efi.signed $(FBNAME).efi.signed
 OBJS	= shim.o netboot.o cert.o replacements.o tpm.o version.o
 KEYS	= shim_cert.h ocsp.* ca.* shim.crt shim.csr shim.p12 shim.pem shim.key shim.cer
-SOURCES	= shim.c shim.h netboot.c include/PeImage.h include/wincert.h include/console.h replacements.c replacements.h tpm.c tpm.h version.c version.h
+ORIG_SOURCES	= shim.c shim.h netboot.c include/PeImage.h include/wincert.h include/console.h replacements.c replacements.h tpm.c tpm.h version.h
 MOK_OBJS = MokManager.o PasswordCrypt.o crypt_blowfish.o
-MOK_SOURCES = MokManager.c shim.h include/console.h PasswordCrypt.c PasswordCrypt.h crypt_blowfish.c crypt_blowfish.h
+ORIG_MOK_SOURCES = MokManager.c shim.h include/console.h PasswordCrypt.c PasswordCrypt.h crypt_blowfish.c crypt_blowfish.h
 FALLBACK_OBJS = fallback.o
-FALLBACK_SRCS = fallback.c
+ORIG_FALLBACK_SRCS = fallback.c
 
 ifneq ($(origin ENABLE_HTTPBOOT), undefined)
 	OBJS += httpboot.o
 	SOURCES += httpboot.c httpboot.h
 endif
 
+SOURCES = $(foreach source,$(ORIG_SOURCES),$(TOPDIR)/$(source)) version.c
+MOK_SOURCES = $(foreach source,$(ORIG_MOK_SOURCES),$(TOPDIR)/$(source))
+FALLBACK_SRCS = $(foreach source,$(ORIG_FALLBACK_SRCS),$(TOPDIR)/$(source))
+
 all: $(TARGET)
 
 shim.crt:
-	./make-certs shim shim@xn--u4h.net all codesign 1.3.6.1.4.1.311.10.3.1 </dev/null
+	$(TOPDIR)/make-certs shim shim@xn--u4h.net all codesign 1.3.6.1.4.1.311.10.3.1 </dev/null
 
 shim.cer: shim.crt
 	$(OPENSSL) x509 -outform der -in $< -out $@
@@ -120,11 +133,11 @@ shim_cert.h: shim.cer
 	$(HEXDUMP) -v -e '1/1 "0x%02x, "' $< >> $@
 	echo "};" >> $@
 
-version.c : version.c.in
+version.c : $(TOPDIR)/version.c.in
 	sed	-e "s,@@VERSION@@,$(VERSION)," \
 		-e "s,@@UNAME@@,$(shell uname -a)," \
 		-e "s,@@COMMIT@@,$(COMMITID)," \
-		< version.c.in > version.c
+		< $< > $@
 
 certdb/secmod.db: shim.crt
 	-mkdir certdb
@@ -132,9 +145,9 @@ certdb/secmod.db: shim.crt
 	$(CERTUTIL) -d certdb/ -A -i shim.crt -n shim -t u
 
 shim.o: $(SOURCES) shim_cert.h
-shim.o: $(wildcard *.h)
+shim.o: $(wildcard $(TOPDIR)/*.h *.h)
 
-cert.o : cert.S
+cert.o : $(TOPDIR)/cert.S
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(SHIMNAME).so: $(OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a
@@ -151,13 +164,16 @@ $(MMNAME).so: $(MOK_OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a l
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS) lib/lib.a
 
 Cryptlib/libcryptlib.a:
-	$(MAKE) -C Cryptlib
+	mkdir -p Cryptlib/{Hash,Hmac,Cipher,Rand,Pk,Pem,SysCall}
+	$(MAKE) VPATH=$(TOPDIR)/Cryptlib TOPDIR=$(TOPDIR)/Cryptlib -C Cryptlib -f $(TOPDIR)/Cryptlib/Makefile
 
 Cryptlib/OpenSSL/libopenssl.a:
-	$(MAKE) -C Cryptlib/OpenSSL
+	mkdir -p Cryptlib/OpenSSL/crypto/{x509v3,x509,txt_db,stack,sha,rsa,rc4,rand,pkcs7,pkcs12,pem,ocsp,objects,modes,md5,lhash,kdf,hmac,evp,err,dso,dh,conf,comp,cmac,buffer,bn,bio,async{,/arch},asn1,aes}/
+	$(MAKE) VPATH=$(TOPDIR)/Cryptlib/OpenSSL TOPDIR=$(TOPDIR)/Cryptlib/OpenSSL -C Cryptlib/OpenSSL -f $(TOPDIR)/Cryptlib/OpenSSL/Makefile
 
 lib/lib.a:
-	$(MAKE) CFLAGS="$(CFLAGS)" -C lib
+	if [ ! -d lib ]; then mkdir lib ; fi
+	$(MAKE) VPATH=$(TOPDIR)/lib TOPDIR=$(TOPDIR) CFLAGS="$(CFLAGS)" -C lib -f $(TOPDIR)/lib/Makefile
 
 ifeq ($(ARCH),aarch64)
 FORMAT		:= -O binary
@@ -194,9 +210,9 @@ endif
 	$(PESIGN) -n certdb -i $< -c "shim" -s -o $@ -f
 
 clean:
-	$(MAKE) -C Cryptlib clean
-	$(MAKE) -C Cryptlib/OpenSSL clean
-	$(MAKE) -C lib clean
+	$(MAKE) -C Cryptlib -f $(TOPDIR)/Cryptlib/Makefile clean
+	$(MAKE) -C Cryptlib/OpenSSL -f $(TOPDIR)/Cryptlib/OpenSSL/Makefile clean
+	$(MAKE) -C lib -f $(TOPDIR)/lib/Makefile clean
 	rm -rf $(TARGET) $(OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb
 	rm -f *.debug *.so *.efi *.tar.* version.c
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,7 +2,7 @@ TARGET = lib.a
 
 LIBFILES = simple_file.o guid.o console.o execute.o configtable.o shell.o variables.o security_policy.o
 
-EFI_INCLUDES    = -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol -I../include
+EFI_INCLUDES    = -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol -I$(TOPDIR)/../include
 
 lib.a: $(LIBFILES)
 	$(AR) rcs lib.a $(LIBFILES)


### PR DESCRIPTION
This lets you do:

mkdir build-x64 build-ia32
cd build-x64
make TOPDIR=.. -f ../Makefile
cd ../build-ia32
setarch i686 -B make ARCH=ia32 TOPDIR=.. -f ../Makefile

And not worry about generated sources and headers mixing and matching.

Signed-off-by: Peter Jones <pjones@redhat.com>