### PR TITLE
Fix build with ENABLE_SHIM_CERT and ENABLE_SBSIGN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,6 +362,6 @@ archive: tag
 	@rm -rf /tmp/shim-$(VERSION)
 	@echo "The archive is in shim-$(VERSION).tar.bz2"
 
-.PHONY : install-deps
+.PHONY : install-deps shim.key
 
 export ARCH CC LD OBJCOPY EFI_INCLUDE


### PR DESCRIPTION
shim.key is created by the shim.crt target

Signed-off-by: Mathieu Trudel-Lapierre <mathieu.trudel-lapierre@canonical.com>