### PR TITLE
Small fixes for Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ shim.crt:
 shim.cer: shim.crt
 	$(OPENSSL) x509 -outform der -in $< -out $@
 
+.NOTPARALLEL: shim_cert.h
 shim_cert.h: shim.cer
 	echo "static UINT8 shim_cert[] = {" > $@
 	$(HEXDUMP) -v -e '1/1 "0x%02x, "' $< >> $@

--- a/Makefile
+++ b/Makefile
@@ -332,7 +332,7 @@ clean:
 	$(MAKE) -C Cryptlib -f $(TOPDIR)/Cryptlib/Makefile clean
 	$(MAKE) -C Cryptlib/OpenSSL -f $(TOPDIR)/Cryptlib/OpenSSL/Makefile clean
 	$(MAKE) -C lib -f $(TOPDIR)/lib/Makefile clean
-	rm -rf $(TARGET) $(OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb
+	rm -rf $(TARGET) $(OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb $(BOOTCSVNAME)
 	rm -f *.debug *.so *.efi *.tar.* version.c
 
 GITTAG = $(VERSION)


### PR DESCRIPTION
boot.csv was not being cleaned by clean; and while building the mallory tree I had some issues with parallel builds (on Ubuntu, gcc version 6.3.0 20170618 (Ubuntu 6.3.0-19ubuntu1), make 4.1):

make -j4 MAKEFILE_LEVEL=0 EFI_PATH=/usr/lib \             
        ENABLE_SHIM_CERT=1 \
        ENABLE_SBSIGN=1

This fails because shim_cert.h might not yet have been dispatched to be built by the time shim.o/netboot.o/etc. are being built (for those source files referencing shim_cert.h).

.NOTPARALLEL forcing shim_cert.h to not be built in parallel with other targets tends to force it to be built earlier. Building keys earlier should not impact the rest of the build process.
