### PR TITLE
Measure binary into the TPM when Shim verify is called

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ DEBUGINFO	?= $(prefix)/lib/debug/
 DEBUGSOURCE	?= $(prefix)/src/debug/
 OSLABEL		?= $(EFIDIR)
 DEFAULT_LOADER	?= \\\\grub$(ARCH_SUFFIX).efi
+REQUIRE_TPM	?=
 
 ARCH		?= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
 OBJCOPY_GTE224	= $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.*\((.*)\|version\) //g' | cut -f1-2 -d.` \>= 2.24)
@@ -66,6 +67,10 @@ endif
 
 ifneq ($(origin ENABLE_HTTPBOOT), undefined)
 	CFLAGS	+= -DENABLE_HTTPBOOT
+endif
+
+ifneq ($(origin REQUIRE_TPM), undefined)
+	CFLAGS	+= -DREQUIRE_TPM
 endif
 
 ifeq ($(ARCH),x86_64)

--- a/README.tpm
+++ b/README.tpm
@@ -3,6 +3,8 @@ The following PCRs are extended by shim:
 PCR4:
 - the Authenticode hash of the binary being loaded will be extended into
   PCR4 before SB verification.
+- the hash of any binary for which Verify is called through the shim_lock
+  protocol
 
 PCR7:
 - Any certificate in one of our certificate databases that matches a binary

--- a/shim.c
+++ b/shim.c
@@ -1308,7 +1308,12 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 		return efi_status;
 
 	/* Measure the binary into the TPM */
-	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, sha1hash, 4);
+	efi_status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, sha1hash, 4);
+#ifdef REQUIRE_TPM
+	if (efi_status != EFI_SUCCESS) {
+		return efi_status;
+	}
+#endif
 
 	if (secure_mode ()) {
 		efi_status = verify_buffer(data, datasize, &context,
@@ -1818,7 +1823,12 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 		goto done;
 
 	/* Measure the binary into the TPM */
-	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, sha1hash, 4);
+	status = tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, sha1hash, 4);
+#ifdef REQUIRE_TPM
+	if (status != EFI_SUCCESS) {
+        goto done;
+	}
+#endif
 
 	if (!secure_mode())
 		goto done;

--- a/shim.c
+++ b/shim.c
@@ -1820,7 +1820,11 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 	if (status != EFI_SUCCESS)
 		goto done;
 
+	/* Measure the binary into the TPM */
+	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, sha1hash, 4);
+
 	status = verify_buffer(buffer, size, &context, sha256hash, sha1hash);
+
 done:
 	in_protocol = 0;
 	return status;

--- a/shim.c
+++ b/shim.c
@@ -1809,9 +1809,6 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 	loader_is_participating = 1;
 	in_protocol = 1;
 
-	if (!secure_mode())
-		goto done;
-
 	status = read_header(buffer, size, &context);
 	if (status != EFI_SUCCESS)
 		goto done;
@@ -1822,6 +1819,9 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 
 	/* Measure the binary into the TPM */
 	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, sha1hash, 4);
+
+	if (!secure_mode())
+		goto done;
 
 	status = verify_buffer(buffer, size, &context, sha256hash, sha1hash);
 

--- a/tpm.c
+++ b/tpm.c
@@ -195,12 +195,15 @@ static EFI_STATUS tpm_log_event_raw(EFI_PHYSICAL_ADDRESS buf, UINTN size,
 		CopyMem(event->Event, (VOID *)log, logsize);
 		if (hash) {
 			/* TPM 2 systems will generate the appropriate hash
-			   themselves if we pass PE_COFF_IMAGE
+			   themselves if we pass PE_COFF_IMAGE.
+               In case that fails we fall back to measuring without it.
 			*/
 			status = uefi_call_wrapper(tpm2->hash_log_extend_event,
 						   5, tpm2, PE_COFF_IMAGE, buf,
 						   (UINT64) size, event);
-		} else {
+		}
+
+        if (!hash || EFI_ERROR(status)) {
 			status = uefi_call_wrapper(tpm2->hash_log_extend_event,
 						   5, tpm2, 0, buf,
 						   (UINT64) size, event);


### PR DESCRIPTION
Currently the only measurement the shim logs in the TPM is that of the EFI
application it directly loads. However, there are no measurements being taken
of application that are being verified through the shim_lock protocol. In this
patch we extend PCR4 for any binary for which Verify is being called through
the shim_lock protocol.

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>