### PR TITLE
Allow compiling 64-bit version on 32-bit host

### DIFF
--- a/Cryptlib/Makefile
+++ b/Cryptlib/Makefile
@@ -6,7 +6,7 @@ CFLAGS		= -ggdb -O0 -I$(TOPDIR) -iquote $(TOPDIR) -fno-stack-protector -fno-stri
 		  -ffreestanding -I$(shell $(CC) -print-file-name=include)
 
 ifeq ($(ARCH),x86_64)
-	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc -maccumulate-outgoing-args \
+	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc -maccumulate-outgoing-args -m64 \
 		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI -DNO_BUILTIN_VA_FUNCS \
 		-DMDE_CPU_X64
 endif

--- a/Cryptlib/OpenSSL/Makefile
+++ b/Cryptlib/OpenSSL/Makefile
@@ -10,7 +10,7 @@ CFLAGS		= -ggdb -O0 -I$(TOPDIR) -I$(TOPDIR)/.. -I$(TOPDIR)/../Include/ -I$(TOPDI
 
 ifeq ($(ARCH),x86_64)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -maccumulate-outgoing-args \
-		-DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI \
+		-m64 -DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI \
 		-UNO_BUILTIN_VA_FUNCS -DMDE_CPU_X64
 endif
 ifeq ($(ARCH),ia32)

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ endif
 
 ifeq ($(ARCH),x86_64)
 	CFLAGS	+= -mno-mmx -mno-sse -mno-red-zone -nostdinc \
-		   -maccumulate-outgoing-args \
+		   -maccumulate-outgoing-args -m64 \
 		   -DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI \
 		   -DNO_BUILTIN_VA_FUNCS -DMDE_CPU_X64 -DPAGE_SIZE=4096
 	LIBDIR			?= $(prefix)/lib64


### PR DESCRIPTION
Add -m64 compiler flag to allow cross-compiling to 64-bit version on 32-bit system

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>