### PR TITLE
Fix Http Boot Enabled build error

### DIFF
--- a/httpboot.c
+++ b/httpboot.c
@@ -37,6 +37,7 @@
 #include "Http.h"
 #include "Ip4Config2.h"
 #include "Ip6Config.h"
+#include "console.h"
 
 #define perror(fmt, ...) ({						\
 		UINTN __perror_ret = 0;					\


### PR DESCRIPTION
Shim 14 no longer builds with http boot enabled.  It appears it is missing an include to console.h since in_protocol was removed.

In addition, this provides Proxy DHCP support for netboot when the boot options are provided via a proxy dhcp instead of the dhcp server.  The second stage bootloader must also implement proxy offers in order for this to work.