### PR TITLE
httpboot: include console.h

### DIFF
--- a/httpboot.c
+++ b/httpboot.c
@@ -34,6 +34,7 @@
 #include <efi.h>
 #include <efilib.h>
 #include "str.h"
+#include "console.h"
 #include "Http.h"
 #include "Ip4Config2.h"
 #include "Ip6Config.h"


### PR DESCRIPTION
in_protocol is declared in console.h, so httpboot.c has to include the
header.

Signed-off-by: Gary Lin <glin@suse.com>