### PR TITLE
Expose ALLOW_32BIT_KERNEL_ON_X64 via Make.defaults

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -59,5 +59,8 @@ Variables you could set to customize the build:
 - OSLABEL
   This is the label that will be put in BOOT$(EFI_ARCH).CSV for your OS.
   By default this is the same value as EFIDIR .
+- ALLOW_32BIT_KERNEL_ON_X64
+  Allow the shim protocol to verify 32-bit kernel even when the shim is 64-bit.
+  Specifying a 32-bit secondary loader with a 64-bit shim is still prohibited.
 
 # vim:filetype=mail:tw=74

--- a/Make.defaults
+++ b/Make.defaults
@@ -101,6 +101,10 @@ ifneq ($(origin REQUIRE_TPM), undefined)
 	CFLAGS  += -DREQUIRE_TPM
 endif
 
+ifneq ($(origin ALLOW_32BIT_KERNEL_ON_X64), undefined)
+    CFLAGS  += -DALLOW_32BIT_KERNEL_ON_X64
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)

--- a/shim.c
+++ b/shim.c
@@ -192,7 +192,13 @@ image_is_loadable(EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr)
 	if (PEHdr->Pe32.FileHeader.Machine != machine_type) {
 		if (!(machine_type == IMAGE_FILE_MACHINE_I386 &&
 		      PEHdr->Pe32.FileHeader.Machine == IMAGE_FILE_MACHINE_X64 &&
-		      allow_64_bit())) {
+		      allow_64_bit())
+#if defined(ALLOW_32BIT_KERNEL_ON_X64)
+		  && !(machine_type == IMAGE_FILE_MACHINE_X64 &&
+		      PEHdr->Pe32.FileHeader.Machine == IMAGE_FILE_MACHINE_I386 &&
+		      allow_32_bit())
+#endif
+		  ) {
 			return 0;
 		}
 	}


### PR DESCRIPTION
The flag ALLOW_32BIT_KERNEL_ON_X64 has already been checked for in shim.c,
in this patch we just expose it through the Makefile.

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>