### PR TITLE
Add Measure function to the shim lock protocol

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -151,10 +151,19 @@ EFI_STATUS
 	PE_COFF_LOADER_IMAGE_CONTEXT *context
 	);
 
+typedef
+EFI_STATUS
+(*EFI_SHIM_LOCK_MEASURE) (
+    IN VOID *buffer,
+    IN UINT32 size,
+    IN UINT8 pcr
+    );
+
 typedef struct _SHIM_LOCK {
 	EFI_SHIM_LOCK_VERIFY Verify;
 	EFI_SHIM_LOCK_HASH Hash;
 	EFI_SHIM_LOCK_CONTEXT Context;
+	EFI_SHIM_LOCK_MEASURE Measure;
 } SHIM_LOCK;
 
 extern EFI_STATUS shim_init(void);


### PR DESCRIPTION
Expand the shim lock protocol to include a "Measure" functionality which can
be used to record hashes into the TPM of arbitrary buffers. The Measure
function will always measure the buffers directly (ie. not with Authenticode),
but for buffers that point to PE images the log will record that it was of a
PE image.

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>