### PR TITLE
shim: Don't overwrite EFI_LOADED_IMAGE's LoadOptions when not needed

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1497,8 +1497,10 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 	li->ImageSize = context.ImageSize;
 
 	/* Pass the load options to the second stage loader */
-	li->LoadOptions = load_options;
-	li->LoadOptionsSize = load_options_size;
+	if ( load_options ) {
+		li->LoadOptions = load_options;
+		li->LoadOptionsSize = load_options_size;
+	}
 
 	if (!found_entry_point) {
 		perror(L"Entry point is not within sections\n");


### PR DESCRIPTION
When the firmware is using EFI_LOAD_OPTION to specify options for the secondary
loader, the shim will properly detect that and return in set_second_stage. Later
howerer in handle_image EFI_LOADED_IMAGE is being overwritten with load_option
irrespective of the fact that load_option was never set. This effectively
prevents the EFI_LOAD_OPTION from reaching the secondary loader.

Only overwrite EFI_LOADED_IMAGE's LoadOptions when load_option is not NULL
solves the problem.

Signed-off-by: Tamas K Lengyel <lengyelt@ainfosec.com>