### PR TITLE
Add a countdown menu to fallback

### DIFF
--- a/MokManager.c
+++ b/MokManager.c
@@ -729,30 +729,6 @@ done:
 	return efi_status;
 }
 
-static void console_save_and_set_mode(SIMPLE_TEXT_OUTPUT_MODE * SavedMode)
-{
-	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
-
-	if (!SavedMode) {
-		console_print(L"Invalid parameter: SavedMode\n");
-		return;
-	}
-
-	CopyMem(SavedMode, co->Mode, sizeof(SIMPLE_TEXT_OUTPUT_MODE));
-	co->EnableCursor(co, FALSE);
-	co->SetAttribute(co, EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE);
-}
-
-static void console_restore_mode(SIMPLE_TEXT_OUTPUT_MODE * SavedMode)
-{
-	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
-
-	co->EnableCursor(co, SavedMode->CursorVisible);
-	co->SetCursorPosition(co, SavedMode->CursorColumn,
-				SavedMode->CursorRow);
-	co->SetAttribute(co, SavedMode->Attribute);
-}
-
 static INTN reset_system()
 {
 	gRT->ResetSystem(EfiResetWarm, EFI_SUCCESS, 0, NULL);
@@ -2033,51 +2009,15 @@ static BOOLEAN verify_pw(BOOLEAN * protected)
 
 static int draw_countdown()
 {
-	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
-	SIMPLE_INPUT_INTERFACE *ci = ST->ConIn;
-	SIMPLE_TEXT_OUTPUT_MODE SavedMode;
-	EFI_INPUT_KEY key;
-	EFI_STATUS efi_status;
-	UINTN cols, rows;
-	CHAR16 *title[2];
 	CHAR16 *message = L"Press any key to perform MOK management";
-	int timeout = 10, wait = 10000000;
+	CHAR16 *title;
+	int timeout;
 
-	console_save_and_set_mode(&SavedMode);
+	title = PoolPrint(L"%s UEFI key management", SHIM_VENDOR);
 
-	title[0] = PoolPrint(L"%s UEFI key management", SHIM_VENDOR);
-	title[1] = NULL;
+	timeout = console_countdown(title, message, 10);
 
-	console_print_box_at(title, -1, 0, 0, -1, -1, 1, 1);
-
-	co->QueryMode(co, co->Mode->Mode, &cols, &rows);
-
-	console_print_at((cols - StrLen(message)) / 2, rows / 2, message);
-	while (1) {
-		if (timeout > 1)
-			console_print_at(2, rows - 3,
-					 L"Booting in %d seconds  ",
-					 timeout);
-		else if (timeout)
-			console_print_at(2, rows - 3,
-					 L"Booting in %d second   ",
-					 timeout);
-
-		efi_status = WaitForSingleEvent(ci->WaitForKey, wait);
-		if (efi_status != EFI_TIMEOUT) {
-			/* Clear the key in the queue */
-			ci->ReadKeyStroke(ci, &key);
-			break;
-		}
-
-		timeout--;
-		if (!timeout)
-			break;
-	}
-
-	FreePool(title[0]);
-
-	console_restore_mode(&SavedMode);
+	FreePool(title);
 
 	return timeout;
 }

--- a/fallback.c
+++ b/fallback.c
@@ -12,6 +12,8 @@
 
 #include "shim.h"
 
+#define NO_REBOOT L"FB_NO_REBOOT"
+
 EFI_LOADED_IMAGE *this_image = NULL;
 
 int
@@ -973,6 +975,65 @@ try_start_first_option(EFI_HANDLE parent_image_handle)
 	return efi_status;
 }
 
+static UINT32
+get_fallback_no_reboot(void)
+{
+	EFI_STATUS efi_status;
+	UINT32 no_reboot;
+	UINTN size = sizeof(UINT32);
+
+	efi_status = gRT->GetVariable(NO_REBOOT, &SHIM_LOCK_GUID,
+				      NULL, &size, &no_reboot);
+	if (!EFI_ERROR(efi_status)) {
+		return no_reboot;
+	}
+	return 0;
+}
+
+static EFI_STATUS
+set_fallback_no_reboot(void)
+{
+	EFI_STATUS efi_status;
+	UINT32 no_reboot = 1;
+	efi_status = gRT->SetVariable(NO_REBOOT, &SHIM_LOCK_GUID,
+				      EFI_VARIABLE_NON_VOLATILE
+				      | EFI_VARIABLE_BOOTSERVICE_ACCESS
+				      | EFI_VARIABLE_RUNTIME_ACCESS,
+				      sizeof(UINT32), &no_reboot);
+	return efi_status;
+}
+
+static int
+draw_countdown(void)
+{
+	CHAR16 *title = L"Boot Option Restoration";
+	CHAR16 *message = L"Press any key to stop system reset";
+	int timeout;
+
+	timeout = console_countdown(title, message, 5);
+
+	return timeout;
+}
+
+static int
+get_user_choice(void)
+{
+	int choice;
+	CHAR16 *title[] = {L"Boot Option Restored", NULL};
+	CHAR16 *menu_strings[] = {
+		L"Reset system",
+		L"Continue boot",
+		L"Always continue boot",
+		NULL
+	};
+
+	do {
+		choice = console_select(title, menu_strings, 0);
+	} while (choice < 0 || choice > 2);
+
+	return choice;
+}
+
 extern EFI_STATUS
 efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *systab);
 
@@ -1039,6 +1100,26 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
 		VerbosePrint(L"tpm not present, starting the first image\n");
 		try_start_first_option(image);
 	} else {
+		if (get_fallback_no_reboot() == 1) {
+			VerbosePrint(L"NO_REBOOT is set, starting the first image\n");
+			try_start_first_option(image);
+		}
+
+		int timeout = draw_countdown();
+		if (timeout == 0)
+			goto reset;
+
+		int choice = get_user_choice();
+		if (choice == 0) {
+			goto reset;
+		} else if (choice == 2) {
+			efi_status = set_fallback_no_reboot();
+			if (EFI_ERROR(efi_status))
+				goto reset;
+		}
+		VerbosePrint(L"tpm present, starting the first image\n");
+		try_start_first_option(image);
+reset:
 		VerbosePrint(L"tpm present, resetting system\n");
 	}
 

--- a/include/console.h
+++ b/include/console.h
@@ -33,6 +33,12 @@ console_alertbox(CHAR16 **title);
 void
 console_notify(CHAR16 *string);
 void
+console_save_and_set_mode(SIMPLE_TEXT_OUTPUT_MODE * SavedMode);
+void
+console_restore_mode(SIMPLE_TEXT_OUTPUT_MODE * SavedMode);
+int
+console_countdown(CHAR16* title, const CHAR16* message, int timeout);
+void
 console_reset(void);
 #define NOSEL 0x7fffffff
 

--- a/lib/console.c
+++ b/lib/console.c
@@ -409,6 +409,82 @@ console_notify(CHAR16 *string)
 	console_alertbox(str_arr);
 }
 
+void
+console_save_and_set_mode(SIMPLE_TEXT_OUTPUT_MODE * SavedMode)
+{
+	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
+
+	if (!SavedMode) {
+		console_print(L"Invalid parameter: SavedMode\n");
+		return;
+	}
+
+	CopyMem(SavedMode, co->Mode, sizeof(SIMPLE_TEXT_OUTPUT_MODE));
+	co->EnableCursor(co, FALSE);
+	co->SetAttribute(co, EFI_LIGHTGRAY | EFI_BACKGROUND_BLUE);
+}
+
+void
+console_restore_mode(SIMPLE_TEXT_OUTPUT_MODE * SavedMode)
+{
+	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
+
+	co->EnableCursor(co, SavedMode->CursorVisible);
+	co->SetCursorPosition(co, SavedMode->CursorColumn,
+				SavedMode->CursorRow);
+	co->SetAttribute(co, SavedMode->Attribute);
+}
+
+int
+console_countdown(CHAR16* title, const CHAR16* message,
+		  int timeout)
+{
+	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
+	SIMPLE_INPUT_INTERFACE *ci = ST->ConIn;
+	SIMPLE_TEXT_OUTPUT_MODE SavedMode;
+	EFI_INPUT_KEY key;
+	EFI_STATUS efi_status;
+	UINTN cols, rows;
+	CHAR16 *titles[2];
+	int wait = 10000000;
+
+	console_save_and_set_mode(&SavedMode);
+
+	titles[0] = title;
+	titles[1] = NULL;
+
+	console_print_box_at(titles, -1, 0, 0, -1, -1, 1, 1);
+
+	co->QueryMode(co, co->Mode->Mode, &cols, &rows);
+
+	console_print_at((cols - StrLen(message)) / 2, rows / 2, message);
+	while (1) {
+		if (timeout > 1)
+			console_print_at(2, rows - 3,
+					 L"Booting in %d seconds  ",
+					 timeout);
+		else if (timeout)
+			console_print_at(2, rows - 3,
+					 L"Booting in %d second   ",
+					 timeout);
+
+		efi_status = WaitForSingleEvent(ci->WaitForKey, wait);
+		if (efi_status != EFI_TIMEOUT) {
+			/* Clear the key in the queue */
+			ci->ReadKeyStroke(ci, &key);
+			break;
+		}
+
+		timeout--;
+		if (!timeout)
+			break;
+	}
+
+	console_restore_mode(&SavedMode);
+
+	return timeout;
+}
+
 #define ARRAY_SIZE(a) (sizeof (a) / sizeof ((a)[0]))
 
 /* Copy of gnu-efi-3.0 with the added secure boot strings */


### PR DESCRIPTION
When TPM presents, to make the measurement result consistent, fallback should reset the system. However, some machine with faulty firmware may keep loading \EFI\Boot\bootx64.efi -> fbx64.efi, and the system became unusable. To give the user a chance to stop system reset, a 5-seconds countdown menu is added so that the user can interrupt system reset and choose to boot the restored boot option. Besides, the "Always continue boot" option will create a variable, FB_NO_REBOOT, and fallback will just load the restored boot option if the variable exists, so that we can work around the rebooting issue in the faulty machine.