### PR TITLE
Fix for "Section 0 has negative size" error when loading fbaa64.efi

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1377,6 +1377,11 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 	 */
 	Section = context.FirstSection;
 	for (i = 0; i < context.NumberOfSections; i++, Section++) {
+		/* Don't try to copy discardable sections with zero size */
+		if ((Section->Characteristics & EFI_IMAGE_SCN_MEM_DISCARDABLE) &&
+		    !Section->Misc.VirtualSize)
+			continue;
+
 		base = ImageAddress (buffer, context.ImageSize,
 				     Section->VirtualAddress);
 		end = ImageAddress (buffer, context.ImageSize,


### PR DESCRIPTION
The current code is incorrectly failing to load the fbaa64.efi image found
in Arm servers even though the UEFI shell code is able to properly load
and execute the same image.

Aside from my own test cases involving KVM guests running on Arm, I'm
pretty sure this addresses the root cause for problems others have reported
as well such as:
https://bugzilla.redhat.com/show_bug.cgi?id=1527283
https://bugzilla.redhat.com/show_bug.cgi?id=1489604

I've tested this patch on an Arm64 server and confirmed the problem
is resolved. I've also tested the patches on an x86 machine to confirm
there were no regressions.