### PR TITLE
Ignore *.hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ shim_cert.h
 *.srl
 *.srl.old
 *.tar.*
+*.hash
 version.c
 cov-int/
 scan-results/


### PR DESCRIPTION
*.hash should be ignored by git status if ENABLE_SHIM_HASH is
configured.

Signed-off-by: Jia Zhang <zhang.jia@linux.alibaba.com>