### PR TITLE
Make EFI variable copying fatal only on secureboot enabled systems

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -2628,7 +2628,18 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	 * boot-services-only state variables are what we think they are.
 	 */
 	efi_status = import_mok_state(image_handle);
-	if (EFI_ERROR(efi_status)) {
+	if (!secure_mode() && efi_status == EFI_INVALID_PARAMETER) {
+		/*
+		 * Make copy failures fatal only if secure_mode is enabled, or
+		 * the error was anything else than EFI_INVALID_PARAMETER.
+		 * There are non-secureboot firmware implementations that don't
+		 * reserve enough EFI variable memory to fit the variable.
+		 */
+		console_print(L"Importing MOK states has failed: %s: %r\n",
+			      msgs[msg], efi_status);
+		console_print(L"Continuing boot since secure mode is disabled");
+	}
+	else if (EFI_ERROR(efi_status)) {
 die:
 		console_print(L"Something has gone seriously wrong: %s: %r\n",
 			      msgs[msg], efi_status);


### PR DESCRIPTION
I have come across systems that are unwilling to reserve enough memory for
a MokListRT big enough for big certificates.
This seems to be the case with firmware implementations that do not support
secureboot, which is probably the reason they went with much lower variable
storage.

This patch set makes sure we can still boot on those systems, by only
making the copy action fatal if the system has secure boot enabled, or if
the error was anything other than EFI_INVALID_PARAMETER.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>