### PR TITLE
Remove call to TPM2 get_event_log()

### DIFF
--- a/tpm.c
+++ b/tpm.c
@@ -70,41 +70,6 @@ static BOOLEAN tpm2_present(EFI_TCG2_BOOT_SERVICE_CAPABILITY *caps,
 	return FALSE;
 }
 
-static inline EFI_TCG2_EVENT_LOG_BITMAP
-tpm2_get_supported_logs(efi_tpm2_protocol_t *tpm,
-			EFI_TCG2_BOOT_SERVICE_CAPABILITY *caps,
-			BOOLEAN old_caps)
-{
-	if (old_caps)
-		return ((TREE_BOOT_SERVICE_CAPABILITY *)caps)->SupportedEventLogs;
-
-	return caps->SupportedEventLogs;
-}
-
-/*
- * According to TCG EFI Protocol Specification for TPM 2.0 family,
- * all events generated after the invocation of EFI_TCG2_GET_EVENT_LOG
- * shall be stored in an instance of an EFI_CONFIGURATION_TABLE aka
- * EFI TCG 2.0 final events table. Hence, it is necessary to trigger the
- * internal switch through calling get_event_log() in order to allow
- * to retrieve the logs from OS runtime.
- */
-static EFI_STATUS trigger_tcg2_final_events_table(efi_tpm2_protocol_t *tpm2,
-						  EFI_TCG2_EVENT_LOG_BITMAP supported_logs)
-{
-	EFI_TCG2_EVENT_LOG_FORMAT log_fmt;
-	EFI_PHYSICAL_ADDRESS start;
-	EFI_PHYSICAL_ADDRESS end;
-	BOOLEAN truncated;
-
-	if (supported_logs & EFI_TCG2_EVENT_LOG_FORMAT_TCG_2)
-		log_fmt = EFI_TCG2_EVENT_LOG_FORMAT_TCG_2;
-	else
-		log_fmt = EFI_TCG2_EVENT_LOG_FORMAT_TCG_1_2;
-
-	return tpm2->get_event_log(tpm2, log_fmt, &start, &end, &truncated);
-}
-
 static EFI_STATUS tpm_locate_protocol(efi_tpm_protocol_t **tpm,
 				      efi_tpm2_protocol_t **tpm2,
 				      BOOLEAN *old_caps_p,
@@ -166,17 +131,6 @@ static EFI_STATUS tpm_log_event_raw(EFI_PHYSICAL_ADDRESS buf, UINTN size,
 #endif
 	} else if (tpm2) {
 		EFI_TCG2_EVENT *event;
-		EFI_TCG2_EVENT_LOG_BITMAP supported_logs;
-
-		supported_logs = tpm2_get_supported_logs(tpm2, &caps, old_caps);
-
-		efi_status = trigger_tcg2_final_events_table(tpm2,
-							     supported_logs);
-		if (EFI_ERROR(efi_status)) {
-			perror(L"Unable to trigger tcg2 final events table: %r\n",
-			       efi_status);
-			return efi_status;
-		}
 
 		event = AllocatePool(sizeof(*event) + logsize);
 		if (!event) {


### PR DESCRIPTION
Calling the TPM2 get_event_log causes the firmware to start logging
events to the final events table, but implementations may also continue
logging to the boot services event log. Any OS that wishes to
reconstruct the full PCR state must already look at both the final
events log and the boot services event log, so if this call is made
anywhere other than immediately before ExitBootServices() then the OS
must deduplicate events that occur in both, complicating things
immensely.

Linux already has support for copying up the boot services event log
across the ExitBootServices() boundary, so there's no reason to make
this call. Remove it.

Signed-off-by: Matthew Garrett <mjg59@google.com>