### PR TITLE
shim: only include shim_cert.h in shim.c

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -35,6 +35,10 @@
 
 #include "shim.h"
 
+#ifdef ENABLE_SHIM_CERT
+#include "shim_cert.h"
+#endif
+
 #include <stdarg.h>
 
 #include <openssl/err.h>

--- a/shim.h
+++ b/shim.h
@@ -120,9 +120,6 @@
 #include "include/variables.h"
 
 #include "version.h"
-#ifdef ENABLE_SHIM_CERT
-#include "shim_cert.h"
-#endif
 
 INTERFACE_DECL(_SHIM_LOCK);
 


### PR DESCRIPTION
Currently shim_cert.h was included in shim.h. This made every user of
shim.h create its own shim_cert array and growed the overall file size.
Since shim_cert is only used in shim.c, it should be only included in
shim.c.

Signed-off-by: Gary Lin <glin@suse.com>