### PR TITLE
Fix MOK variables mirroring and duplicate shim_cert

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -68,6 +68,10 @@ struct mok_state_variable {
 	 */
 	UINT8 **addend_source;
 	UINT32 *addend_size;
+#if defined(ENABLE_SHIM_CERT)
+	UINT8 **build_cert;
+	UINT32 *build_cert_size;
+#endif /* defined(ENABLE_SHIM_CERT) */
 	UINT32 yes_attr;
 	UINT32 no_attr;
 	UINT32 flags;
@@ -90,6 +94,10 @@ struct mok_state_variable mok_state_variables[] = {
 	 .no_attr = EFI_VARIABLE_RUNTIME_ACCESS,
 	 .addend_source = &vendor_cert,
 	 .addend_size = &vendor_cert_size,
+#if defined(ENABLE_SHIM_CERT)
+	 .build_cert = &build_cert,
+	 .build_cert_size = &build_cert_size,
+#endif /* defined(ENABLE_SHIM_CERT) */
 	 .flags = MOK_MIRROR_KEYDB |
 		  MOK_VARIABLE_LOG,
 	 .pcr = 14,
@@ -130,6 +138,22 @@ struct mok_state_variable mok_state_variables[] = {
 	{ NULL, }
 };
 
+inline BOOLEAN check_vendor_cert(struct mok_state_variable *v)
+{
+	return (v->addend_source && v->addend_size &&
+		*v->addend_source && *v->addend_size) ? TRUE : FALSE;
+}
+#if defined(ENABLE_SHIM_CERT)
+inline BOOLEAN check_build_cert(struct mok_state_variable *v)
+{
+	return (v->build_cert && v->build_cert_size &&
+		*v->build_cert && *v->build_cert_size) ? TRUE : FALSE;
+}
+#define check_addend(v) (check_vendor_cert(v) || check_build_cert(v))
+#else
+#define check_addend(v) check_vendor_cert(v)
+#endif /* defined(ENABLE_SHIM_CERT) */
+
 static EFI_STATUS mirror_one_mok_variable(struct mok_state_variable *v)
 {
 	EFI_STATUS efi_status = EFI_SUCCESS;
@@ -137,15 +161,27 @@ static EFI_STATUS mirror_one_mok_variable(struct mok_state_variable *v)
 	UINTN FullDataSize = 0;
 	uint8_t *p = NULL;
 
-	if ((v->flags & MOK_MIRROR_KEYDB) &&
-	    v->addend_source && *v->addend_source &&
-	    v->addend_size && *v->addend_size) {
+	if ((v->flags & MOK_MIRROR_KEYDB) && check_addend(v)) {
 		EFI_SIGNATURE_LIST *CertList = NULL;
 		EFI_SIGNATURE_DATA *CertData = NULL;
+#if defined(ENABLE_SHIM_CERT)
+		FullDataSize = v->data_size;
+		if (check_build_cert(v)) {
+			FullDataSize += sizeof (*CertList)
+					+ sizeof (EFI_GUID)
+					+ *v->build_cert_size;
+		}
+		if (check_vendor_cert(v)) {
+			FullDataSize += sizeof (*CertList)
+					+ sizeof (EFI_GUID)
+					+ *v->addend_size;
+		}
+#else
 		FullDataSize = v->data_size
 			     + sizeof (*CertList)
 			     + sizeof (EFI_GUID)
 			     + *v->addend_size;
+#endif /* defined(ENABLE_SHIM_CERT) */
 		FullData = AllocatePool(FullDataSize);
 		if (!FullData) {
 			perror(L"Failed to allocate space for MokListRT\n");
@@ -157,6 +193,35 @@ static EFI_STATUS mirror_one_mok_variable(struct mok_state_variable *v)
 			CopyMem(p, v->data, v->data_size);
 			p += v->data_size;
 		}
+
+#if defined(ENABLE_SHIM_CERT)
+		if (check_build_cert(v) == FALSE)
+			goto skip_build_cert;
+
+		CertList = (EFI_SIGNATURE_LIST *)p;
+		p += sizeof (*CertList);
+		CertData = (EFI_SIGNATURE_DATA *)p;
+		p += sizeof (EFI_GUID);
+
+		CertList->SignatureType = EFI_CERT_TYPE_X509_GUID;
+		CertList->SignatureListSize = *v->build_cert_size
+					      + sizeof (*CertList)
+					      + sizeof (*CertData)
+					      -1;
+		CertList->SignatureHeaderSize = 0;
+		CertList->SignatureSize = *v->build_cert_size +
+					  sizeof (EFI_GUID);
+
+		CertData->SignatureOwner = SHIM_LOCK_GUID;
+		CopyMem(p, *v->build_cert, *v->build_cert_size);
+
+		p += *v->build_cert_size;
+
+		if (check_vendor_cert(v) == FALSE)
+			goto skip_vendor_cert;
+skip_build_cert:
+#endif /* defined(ENABLE_SHIM_CERT) */
+
 		CertList = (EFI_SIGNATURE_LIST *)p;
 		p += sizeof (*CertList);
 		CertData = (EFI_SIGNATURE_DATA *)p;
@@ -173,6 +238,9 @@ static EFI_STATUS mirror_one_mok_variable(struct mok_state_variable *v)
 		CertData->SignatureOwner = SHIM_LOCK_GUID;
 		CopyMem(p, *v->addend_source, *v->addend_size);
 
+#if defined(ENABLE_SHIM_CERT)
+skip_vendor_cert:
+#endif /* defined(ENABLE_SHIM_CERT) */
 		if (v->data && v->data_size)
 			FreePool(v->data);
 		v->data = FullData;
@@ -223,9 +291,7 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 		UINT32 attrs = 0;
 		BOOLEAN delete = FALSE, present, addend;
 
-		addend = (v->addend_source && v->addend_size &&
-			  *v->addend_source && *v->addend_size)
-			? TRUE : FALSE;
+		addend = check_addend(v);
 
 		efi_status = get_variable_attr(v->name,
 					       &v->data, &v->data_size,

--- a/mok.c
+++ b/mok.c
@@ -223,11 +223,18 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 		UINT32 attrs = 0;
 		BOOLEAN delete = FALSE, present, addend;
 
+		addend = (v->addend_source && v->addend_size &&
+			  *v->addend_source && *v->addend_size)
+			? TRUE : FALSE;
+
 		efi_status = get_variable_attr(v->name,
 					       &v->data, &v->data_size,
 					       *v->guid, &attrs);
-		if (efi_status == EFI_NOT_FOUND)
+		if (efi_status == EFI_NOT_FOUND) {
+			if (addend)
+				goto mirror_addend;
 			continue;
+		}
 		if (EFI_ERROR(efi_status)) {
 			perror(L"Could not verify %s: %r\n", v->name,
 			       efi_status);
@@ -272,9 +279,6 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 		}
 
 		present = (v->data && v->data_size) ? TRUE : FALSE;
-		addend = (v->addend_source && v->addend_size &&
-			  *v->addend_source && *v->addend_size)
-			? TRUE : FALSE;
 
 		if (v->flags & MOK_VARIABLE_MEASURE && present) {
 			/*
@@ -304,7 +308,8 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 			}
 		}
 
-		if (v->rtname && present && addend) {
+mirror_addend:
+		if (v->rtname && (present || addend)) {
 			if (v->flags & MOK_MIRROR_DELETE_FIRST)
 				LibDeleteVariable(v->rtname, v->guid);
 

--- a/shim.c
+++ b/shim.c
@@ -34,6 +34,9 @@
  */
 
 #include "shim.h"
+#if defined(ENABLE_SHIM_CERT)
+#include "shim_cert.h"
+#endif /* defined(ENABLE_SHIM_CERT) */
 
 #include <stdarg.h>
 
@@ -77,6 +80,10 @@ UINT32 vendor_cert_size;
 UINT32 vendor_dbx_size;
 UINT8 *vendor_cert;
 UINT8 *vendor_dbx;
+#if defined(ENABLE_SHIM_CERT)
+UINT32 build_cert_size;
+UINT8 *build_cert;
+#endif /* defined(ENABLE_SHIM_CERT) */
 
 /*
  * indicator of how an image has been verified
@@ -2592,6 +2599,10 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	vendor_dbx_size = cert_table.vendor_dbx_size;
 	vendor_cert = (UINT8 *)&cert_table + cert_table.vendor_cert_offset;
 	vendor_dbx = (UINT8 *)&cert_table + cert_table.vendor_dbx_offset;
+#if defined(ENABLE_SHIM_CERT)
+	build_cert_size = sizeof(shim_cert);
+	build_cert = shim_cert;
+#endif /* defined(ENABLE_SHIM_CERT) */
 	CHAR16 *msgs[] = {
 		L"import_mok_state() failed\n",
 		L"shim_int() failed\n",

--- a/shim.h
+++ b/shim.h
@@ -120,9 +120,6 @@
 #include "include/variables.h"
 
 #include "version.h"
-#ifdef ENABLE_SHIM_CERT
-#include "shim_cert.h"
-#endif
 
 INTERFACE_DECL(_SHIM_LOCK);
 
@@ -170,6 +167,10 @@ extern UINT32 vendor_cert_size;
 extern UINT32 vendor_dbx_size;
 extern UINT8 *vendor_cert;
 extern UINT8 *vendor_dbx;
+#if defined(ENABLE_SHIM_CERT)
+extern UINT32 build_cert_size;
+extern UINT8 *build_cert;
+#endif /* defined(ENABLE_SHIM_CERT) */
 
 extern UINT8 user_insecure_mode;
 extern UINT8 ignore_db;


### PR DESCRIPTION
As mentioned in https://github.com/rhboot/shim/issues/154 and https://github.com/rhboot/shim/pull/153, the vendor certificate wasn't mirrored correctly. Besides, a faulty check also stopped several MOK variables from being mirrored.

During my testing, I also found that the auto-generated build certificate wasn't handled properly. Every user of shim_cert.h created its own duplicate shim_cert array. The build certificate was also not mirrored to MokListRT.

This PR should fix the mirroring issues above altogether.