### PR TITLE
Makefile: do not run git on clean if there's no .git directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,7 +225,7 @@ clean-shim-objs:
 	@rm -rvf $(TARGET) *.o $(SHIM_OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb $(BOOTCSVNAME)
 	@rm -vf *.debug *.so *.efi *.efi.* *.tar.* version.c buildid
 	@rm -vf Cryptlib/*.[oa] Cryptlib/*/*.[oa]
-	@git clean -f -d -e 'Cryptlib/OpenSSL/*'
+	@if [ -d .git ] ; then git clean -f -d -e 'Cryptlib/OpenSSL/*'; fi
 
 clean: clean-shim-objs
 	$(MAKE) -C Cryptlib -f $(TOPDIR)/Cryptlib/Makefile clean


### PR DESCRIPTION
When building in minimal chroot on build workers, like in Debian (where
make clean is called at the beginning of the build process), git will
not be available. Skip the git clean.

Signed-off-by: Luca Boccassi <bluca@debian.org>