### PR TITLE
Fix apparent typo in ARM 32-on-64 code

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -152,7 +152,7 @@ allow_32_bit(void)
 #endif
 #elif defined(__i386__) || defined(__i686__)
 	return 1;
-#elif defined(__arch64__)
+#elif defined(__aarch64__)
 	return 0;
 #else /* assuming everything else is 32-bit... */
 	return 1;


### PR DESCRIPTION
The architecture is aarch64, not arch64.

Fixes: 750584c20775 ("Make 64-on-32 maybe work on x86_64.")
Signed-off-by: dann frazier <dann.frazier@canonical.com>