### PR TITLE
Fix build failure due to missing closing brace

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -286,6 +286,7 @@ maybe_mirror_one_mok_variable(struct mok_state_variable *v, EFI_STATUS ret)
 				ret = efi_status;
 			perror(L"Could not create %s: %r\n", v->rtname,
 			       efi_status);
+		}
 	}
 	return ret;
 }


### PR DESCRIPTION
Currently the CI [is failing](https://travis-ci.org/rhboot/shim/builds/487111376) because 29c11483101b460869a5e0dba1f425073862127d introduced an unmatched opening brace.

Closes #168