### PR TITLE
Hook exit when shim_lock protocol installed

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -2504,9 +2504,9 @@ shim_init(void)
 			loader_is_participating = 0;
 		}
 
-		hook_exit(systab);
 	}
 
+	hook_exit(systab);
 	return install_shim_protocols();
 }
 
@@ -2524,8 +2524,9 @@ shim_fini(void)
 		 * Remove our hooks from system services.
 		 */
 		unhook_system_services();
-		unhook_exit();
 	}
+
+	unhook_exit();
 
 	/*
 	 * Free the space allocated for the alternative 2nd stage loader


### PR DESCRIPTION
A recent commit moved where the shim_lock protocol is loaded and
unloaded, but did not move where exit was hooked and unhooked.  Exit
needs to be hooked when the protocol is installed, so that the protocol
will be uninstalled on exit.  Otherwise, the system can crash if, for
example, shim loads grub, the user exits grub, shim is run again, which
installs a second instance of the protocol, and then grub tries to use
the shim_lock protocol that was installed by the first instance of shim.

Signed-off-by: Stuart Hayes <stuart.w.hayes@gmail.com>