### PR TITLE
MokManager: Use CompareMem on MokListNode.Type instead of CompareGuid

### DIFF
--- a/MokManager.c
+++ b/MokManager.c
@@ -1053,7 +1053,8 @@ static EFI_STATUS write_back_mok_list(MokListNode * list, INTN key_num,
 			continue;
 
 		DataSize += sizeof(EFI_SIGNATURE_LIST);
-		if (CompareGuid(&(list[i].Type), &X509_GUID) == 0)
+		if (CompareMem(&(list[i].Type), &X509_GUID,
+			       sizeof(EFI_GUID)) == 0)
 			DataSize += sizeof(EFI_GUID);
 		DataSize += list[i].MokSize;
 	}
@@ -1075,7 +1076,8 @@ static EFI_STATUS write_back_mok_list(MokListNode * list, INTN key_num,
 		CertList->SignatureType = list[i].Type;
 		CertList->SignatureHeaderSize = 0;
 
-		if (CompareGuid(&(list[i].Type), &X509_GUID) == 0) {
+		if (CompareMem(&(list[i].Type), &X509_GUID,
+			       sizeof(EFI_GUID)) == 0) {
 			CertList->SignatureListSize = list[i].MokSize +
 			    sizeof(EFI_SIGNATURE_LIST) + sizeof(EFI_GUID);
 			CertList->SignatureSize =
@@ -1116,7 +1118,8 @@ static void delete_cert(void *key, UINT32 key_size,
 	int i;
 
 	for (i = 0; i < mok_num; i++) {
-		if (CompareGuid(&(mok[i].Type), &X509_GUID) != 0)
+		if (CompareMem(&(mok[i].Type), &X509_GUID,
+			       sizeof(EFI_GUID)) != 0)
 			continue;
 
 		if (mok[i].MokSize == key_size &&
@@ -1167,7 +1170,7 @@ static void delete_hash_in_list(EFI_GUID Type, UINT8 * hash, UINT32 hash_size,
 	sig_size = hash_size + sizeof(EFI_GUID);
 
 	for (i = 0; i < mok_num; i++) {
-		if ((CompareGuid(&(mok[i].Type), &Type) != 0) ||
+		if ((CompareMem(&(mok[i].Type), &Type, sizeof(EFI_GUID)) != 0) ||
 		    (mok[i].MokSize < sig_size))
 			continue;
 
@@ -1331,7 +1334,8 @@ static EFI_STATUS delete_keys(void *MokDel, UINTN MokDelSize, BOOLEAN MokX)
 
 	/* Search and destroy */
 	for (i = 0; i < del_num; i++) {
-		if (CompareGuid(&(del_key[i].Type), &X509_GUID) == 0) {
+		if (CompareMem(&(del_key[i].Type), &X509_GUID,
+			       sizeof(EFI_GUID)) == 0) {
 			delete_cert(del_key[i].Mok, del_key[i].MokSize,
 				    mok, mok_num);
 		} else if (is_sha2_hash(del_key[i].Type)) {


### PR DESCRIPTION
Fix the errors from gcc9 '-Werror=address-of-packed-member'

https://github.com/rhboot/shim/issues/161

Signed-off-by: Gary Lin <glin@suse.com>