### PR TITLE
VLogError(): Avoid NULL pointer dereferences in (V)SPrint calls

### DIFF
--- a/errlog.c
+++ b/errlog.c
@@ -14,29 +14,20 @@ EFI_STATUS
 VLogError(const char *file, int line, const char *func, CHAR16 *fmt, va_list args)
 {
 	va_list args2;
-	UINTN size = 0, size2;
 	CHAR16 **newerrs;
-
-	size = SPrint(NULL, 0, L"%a:%d %a() ", file, line, func);
-	va_copy(args2, args);
-	size2 = VSPrint(NULL, 0, fmt, args2);
-	va_end(args2);
 
 	newerrs = ReallocatePool(errs, (nerrs + 1) * sizeof(*errs),
 				       (nerrs + 3) * sizeof(*errs));
 	if (!newerrs)
 		return EFI_OUT_OF_RESOURCES;
 
-	newerrs[nerrs] = AllocatePool(size*2+2);
+	newerrs[nerrs] = PoolPrint(L"%a:%d %a() ", file, line, func);
 	if (!newerrs[nerrs])
 		return EFI_OUT_OF_RESOURCES;
-	newerrs[nerrs+1] = AllocatePool(size2*2+2);
+	va_copy(args2, args);
+	newerrs[nerrs+1] = VPoolPrint(fmt, args2);
 	if (!newerrs[nerrs+1])
 		return EFI_OUT_OF_RESOURCES;
-
-	SPrint(newerrs[nerrs], size*2+2, L"%a:%d %a() ", file, line, func);
-	va_copy(args2, args);
-	VSPrint(newerrs[nerrs+1], size2*2+2, fmt, args2);
 	va_end(args2);
 
 	nerrs += 2;


### PR DESCRIPTION
VLogError() calculates the size of format strings by using calls to
SPrint and VSPrint with a StrSize of 0 and NULL for an output buffer.
Unfortunately, this is an incorrect usage of (V)Sprint. A StrSize
of "0" is special-cased to mean "there is no limit". So, we end up
writing our string to address 0x0. This was discovered because it
causes a crash on ARM where, unlike x86, it does not necessarily
have memory mapped at 0x0.

Replace the (V)SPrint calls with (V)PoolPrint calls, and we can use
StrLen() to calculate the size. Downside is that PoolPrint will
allocate pool memory to do this, so we need to release it.

Fixes: 25f6fd08cd26 ("try to show errors more usefully.")
Signed-off-by: dann frazier <dann.frazier@canonical.com>