### PR TITLE
Fix OBJ_create() to tolerate a NULL sn and ln

### DIFF
--- a/Cryptlib/OpenSSL/crypto/objects/obj_dat.c
+++ b/Cryptlib/OpenSSL/crypto/objects/obj_dat.c
@@ -685,7 +685,8 @@ int OBJ_create(const char *oid, const char *sn, const char *ln)
     int ok = 0;
 
     /* Check to see if short or long name already present */
-    if (OBJ_sn2nid(sn) != NID_undef || OBJ_ln2nid(ln) != NID_undef) {
+    if ((sn != NULL && OBJ_sn2nid(sn) != NID_undef)
+            || (ln != NULL && OBJ_ln2nid(ln) != NID_undef)) {
         OBJerr(OBJ_F_OBJ_CREATE, OBJ_R_OID_EXISTS);
         return 0;
     }


### PR DESCRIPTION
From: https://github.com/openssl/openssl/commit/f13615c5b828aeb8e3d9bf2545c803633d1c684f

Apply an upstream patch from OpenSSL to tolerate a NULL sn. This avoids
a NULL pointer reference in shim.c:verify_eku(). This was discovered
because it causes a crash on ARM where, unlike x86, it does not necessarily
have memory mapped at 0x0.

Fixes: 6c180c6004ac ("shim: verify Extended Key Usage flags")
Signed-off-by: dann frazier <dann.frazier@canonical.com>