### PR TITLE
Remove undesired output dppath and path variables

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -2146,8 +2146,6 @@ static int is_our_path(EFI_LOADED_IMAGE *li, CHAR16 *path)
 		goto done;
 	}
 
-	dprint(L"dppath: %s\n", dppath);
-	dprint(L"path:   %s\n", path);
 	if (StrnCaseCmp(dppath, PathName, strlen(dppath)))
 		ret = 0;
 


### PR DESCRIPTION
When passing arguments to shim, it outputs the contents of dppath and path
variables. Seems to be a debug leftover.

Signed-off-by: David Santamaría Rogado <howl.nsp@gmail.com>