### PR TITLE
tpm: Don't log duplicate identical events

### DIFF
--- a/tpm.c
+++ b/tpm.c
@@ -239,7 +239,7 @@ static BOOLEAN tpm_data_measured(CHAR16 *VarName, EFI_GUID VendorGuid, UINTN Var
 
 	for (i=0; i<measuredcount; i++) {
 		if ((StrCmp (VarName, measureddata[i].VariableName) == 0) &&
-		    (CompareGuid (&VendorGuid, measureddata[i].VendorGuid)) &&
+		    (CompareGuid (&VendorGuid, measureddata[i].VendorGuid) == 0) &&
 		    (VarSize == measureddata[i].Size) &&
 		    (CompareMem (VarData, measureddata[i].Data, VarSize) == 0)) {
 			return TRUE;


### PR DESCRIPTION
According to the comment in tpm_measure_variable ("Don't measure something that we've already measured"), shim shouldn't measure duplicate events if they are identical, which also aligns with section 2.3.4.8 of the TCG PC Client Platform Firmware Profile Specification ("If it has been measured previously, it MUST NOT be measured again"). This is currently broken because tpm_data_measured() uses the return value of CompareGuid() incorrectly.