### PR TITLE
Fix typo in lib/console.c EFI_WARN_UNKNOWN_GLYPH definition

### DIFF
--- a/lib/console.c
+++ b/lib/console.c
@@ -520,7 +520,7 @@ static struct {
 	{  EFI_SECURITY_VIOLATION,     L"Security Violation"},
 
 	// warnings
-	{  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
+	{  EFI_WARN_UNKNOWN_GLYPH,      L"Warning Unknown Glyph"},
 	{  EFI_WARN_DELETE_FAILURE,    L"Warning Delete Failure"},
 	{  EFI_WARN_WRITE_FAILURE,     L"Warning Write Failure"},
 	{  EFI_WARN_BUFFER_TOO_SMALL,  L"Warning Buffer Too Small"},


### PR DESCRIPTION
A typo still present in lib/console.c EFI_WARN_UNKNOWN_GLYPH definition makes shim unbuildable against system gnu-efi 3.0.10+

https://sourceforge.net/p/gnu-efi/code/ci/5d0d538c2574dfe32e87e87ff977f2830ae2990c/
https://sourceforge.net/p/gnu-efi/code/ci/d34132e62f666904158c7ec2f1eef5a9d5281c36/