### PR TITLE
lib: move print_crypto_errors() out of console.c

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,7 @@
 TARGET = lib.a
 
-LIBFILES = simple_file.o guid.o console.o execute.o configtable.o shell.o variables.o security_policy.o
+LIBFILES = simple_file.o guid.o console.o execute.o configtable.o shell.o variables.o security_policy.o \
+	   print_crypto.o
 
 EFI_INCLUDES    = -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol -I$(TOPDIR)/../include \
 		  -I$(TOPDIR)/CryptLib/Include/openssl/

--- a/lib/console.c
+++ b/lib/console.c
@@ -598,33 +598,6 @@ setup_verbosity(VOID)
 	setup_console(-1);
 }
 
-/* Included here because they mess up the definition of va_list and friends */
-#include <Library/BaseCryptLib.h>
-#include <openssl/err.h>
-#include <openssl/crypto.h>
-
-static int
-print_errors_cb(const char *str, size_t len, void *u)
-{
-	console_print(L"%a", str);
-
-	return len;
-}
-
-EFI_STATUS
-print_crypto_errors(EFI_STATUS efi_status,
-		    char *file, const char *func, int line)
-{
-	if (!(verbose && EFI_ERROR(efi_status)))
-		return efi_status;
-
-	console_print(L"SSL Error: %a:%d %a(): %r\n", file, line, func,
-		      efi_status);
-	ERR_print_errors_cb(print_errors_cb, NULL);
-
-	return efi_status;
-}
-
 VOID
 msleep(unsigned long msecs)
 {

--- a/lib/print_crypto.c
+++ b/lib/print_crypto.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 SUSE LLC <glin@suse.com>
+ *
+ * see COPYING file
+ */
+
+#include <efi.h>
+#include <efilib.h>
+#include <stdarg.h>
+
+#include "shim.h"
+
+#include <Library/BaseCryptLib.h>
+#include <openssl/err.h>
+#include <openssl/crypto.h>
+#include <console.h>
+
+static int
+print_errors_cb(const char *str, size_t len, void *u)
+{
+	console_print(L"%a", str);
+
+	return len;
+}
+
+EFI_STATUS
+print_crypto_errors(EFI_STATUS efi_status,
+		    char *file, const char *func, int line)
+{
+	if (!(verbose && EFI_ERROR(efi_status)))
+		return efi_status;
+
+	console_print(L"SSL Error: %a:%d %a(): %r\n", file, line, func,
+		      efi_status);
+	ERR_print_errors_cb(print_errors_cb, NULL);
+
+	return efi_status;
+}


### PR DESCRIPTION
print_crypto_errors() will pull in the whole openssl library which
bloats the size of fallback.efi. Move the function to an independent
file (lib/print_crypto.c) to reduce the file size of fallback.efi from
1.3MB to 93KB.

Signed-off-by: Gary Lin <glin@suse.com>