### PR TITLE
Include information about PE/COFF images in the TPM Event Log

### DIFF
--- a/include/tpm.h
+++ b/include/tpm.h
@@ -10,8 +10,9 @@ EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,
 			 const CHAR8 *description);
 EFI_STATUS fallback_should_prefer_reset(void);
 
-EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 *sha1hash,
-		      UINT8 pcr);
+EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size,
+		      EFI_PHYSICAL_ADDRESS addr, EFI_DEVICE_PATH *path,
+		      UINT8 *sha1hash, UINT8 pcr);
 
 EFI_STATUS tpm_measure_variable(CHAR16 *dbname, EFI_GUID guid, UINTN size, void *data);
 

--- a/src/shim.c
+++ b/src/shim.c
@@ -1207,7 +1207,9 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
 #ifdef REQUIRE_TPM
 	efi_status =
 #endif
-	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, sha1hash, 4);
+	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize,
+		   (EFI_PHYSICAL_ADDRESS)(UINTN)context.ImageAddress,
+		   li->FilePath, sha1hash, 4);
 #ifdef REQUIRE_TPM
 	if (efi_status != EFI_SUCCESS) {
 		return efi_status;
@@ -1721,7 +1723,8 @@ EFI_STATUS shim_verify (void *buffer, UINT32 size)
 #ifdef REQUIRE_TPM
 	efi_status =
 #endif
-	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, sha1hash, 4);
+	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)buffer, size, 0, NULL,
+		   sha1hash, 4);
 #ifdef REQUIRE_TPM
 	if (EFI_ERROR(efi_status))
 		goto done;

--- a/src/tpm.c
+++ b/src/tpm.c
@@ -210,21 +210,39 @@ EFI_STATUS tpm_log_event(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 pcr,
 				 strlena(description) + 1, 0xd, NULL);
 }
 
-EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size, UINT8 *sha1hash,
-		      UINT8 pcr)
+EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size,
+		      EFI_PHYSICAL_ADDRESS addr, EFI_DEVICE_PATH *path,
+		      UINT8 *sha1hash, UINT8 pcr)
 {
-	EFI_IMAGE_LOAD_EVENT ImageLoad;
+	EFI_IMAGE_LOAD_EVENT *ImageLoad = NULL;
+	EFI_STATUS efi_status;
+	UINTN path_size = 0;
 
-	// All of this is informational and forces us to do more parsing before
-	// we can generate it, so let's just leave it out for now
-	ImageLoad.ImageLocationInMemory = 0;
-	ImageLoad.ImageLengthInMemory = 0;
-	ImageLoad.ImageLinkTimeAddress = 0;
-	ImageLoad.LengthOfDevicePath = 0;
+	if (path)
+		path_size = DevicePathSize(path);
 
-	return tpm_log_event_raw(buf, size, pcr, (CHAR8 *)&ImageLoad,
-				 sizeof(ImageLoad),
-				 EV_EFI_BOOT_SERVICES_APPLICATION, sha1hash);
+	ImageLoad = AllocateZeroPool(sizeof(*ImageLoad) + path_size);
+	if (!ImageLoad) {
+		perror(L"Unable to allocate image load event structure\n");
+		return EFI_OUT_OF_RESOURCES;
+	}
+
+	ImageLoad->ImageLocationInMemory = buf;
+	ImageLoad->ImageLengthInMemory = size;
+	ImageLoad->ImageLinkTimeAddress = addr;
+
+	if (path_size > 0) {
+		CopyMem(ImageLoad->DevicePath, path, path_size);
+		ImageLoad->LengthOfDevicePath = path_size;
+	}
+
+	efi_status = tpm_log_event_raw(buf, size, pcr, (CHAR8 *)ImageLoad,
+				       sizeof(*ImageLoad) + path_size,
+				       EV_EFI_BOOT_SERVICES_APPLICATION,
+				       sha1hash);
+	FreePool(ImageLoad);
+
+	return efi_status;
 }
 
 typedef struct {


### PR DESCRIPTION
The [TCG PC Client Specific Platform Firmware Profile Specification](https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClientSpecPlat_TPM_2p0_1p04_pub.pdf) says that when measuring a PE/COFF image, the TCG_PCR_EVENT2 structure Event field MUST contain a UEFI_IMAGE_LOAD_EVENT structure.
    
Currently an empty UEFI_IMAGE_LOAD_EVENT structure is passed so users only have the hash of the PE/COFF image, but not information such the file path of the binary.

The first commit just fixes a bug, and is that the EFI_LOADED_IMAGE FilePath field wasn't updated with the second stage loader path. So the wrong information would be logged if the value is used to fill the EFI_IMAGE_LOAD_EVENT DevicePath field.

The second commit fills the EFI_IMAGE_LOAD_EVENT structure to include the information about the PE/COFF image present in the TPM Event Log.