### PR TITLE
Check PxeReplyReceived as fallback in netboot

### DIFF
--- a/src/netboot.c
+++ b/src/netboot.c
@@ -273,6 +273,15 @@ static EFI_STATUS parseDhcp4()
 			pkt_v4 = &pxe->Mode->ProxyOffer.Dhcpv4;
 	}
 
+	if(pxe->Mode->PxeReplyReceived) {
+		/*
+		 * If we have no bootinfo yet search for it in the PxeReply.
+		 * Some mainboards run into this when the server uses boot menus
+		 */
+		if(pkt_v4->BootpBootFile[0] == '\0' && pxe->Mode->PxeReply.Dhcpv4.BootpBootFile[0] != '\0')
+			pkt_v4 = &pxe->Mode->PxeReply.Dhcpv4;
+	}
+
 	INTN dir_len = strnlena((CHAR8 *)pkt_v4->BootpBootFile, 127);
 	INTN i;
 	CHAR8 *dir = (CHAR8 *)pkt_v4->BootpBootFile;


### PR DESCRIPTION
Some mainboards do not update the ProxyOffset dhcp information when using
proxy dhcp and boot menus.
This adds a fallback to check the PxeReply field if no boot information is
found in the v4 dhcp or proxy dhcp information