### PR TITLE
Convert README -> README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+# shim, a first-stage UEFI bootloader
+
 shim is a trivial EFI application that, when run, attempts to open and
 execute another application. It will initially attempt to do this via the
-standard EFI LoadImage() and StartImage() calls. If these fail (because secure
-boot is enabled and the binary is not signed with an appropriate key, for
+standard EFI `LoadImage()` and `StartImage()` calls. If these fail (because Secure
+Boot is enabled and the binary is not signed with an appropriate key, for
 instance) it will then validate the binary against a built-in certificate. If
 this succeeds and if the binary or signing key are not blacklisted then shim
 will relocate and execute the binary.
@@ -14,10 +16,10 @@ to it should not be wrapped.
 
 On systems with a TPM chip enabled and supported by the system firmware,
 shim will extend various PCRs with the digests of the targets it is
-loading.  A full list is in the file README.tpm .
+loading.  A full list is in the file [README.tpm](README.tpm) .
 
 To use shim, simply place a DER-encoded public certificate in a file such as
-pub.cer and build with "make VENDOR_CERT_FILE=pub.cer".
+pub.cer and build with `make VENDOR_CERT_FILE=pub.cer`.
 
 There are a couple of build options, and a couple of ways to customize the
-build, described in BUILDING.
+build, described in [BUILDING](BUILDING).


### PR DESCRIPTION
One of the really great things about Github IMO is how
"front and center" the README file in a repository is (just
compare with Sourceforge).

Github renders it more nicely if the file is declared to be Markdown,
so let's do that.  Add a bit of formatting: using code fences
for code, hyperlinks for other files etc.

I also added a title block from the Fedora package `Summary`
since while I know in theory shim is independent of bootloaders,
let's say what the 95% case is here.