### PR TITLE
Fix escaping of DEFAULT_LOADER

### DIFF
--- a/include/defaults.mk
+++ b/include/defaults.mk
@@ -34,7 +34,7 @@ DATATARGETDIR	?= $(datadir)/$(PKGNAME)/$(VERSION)$(DASHRELEASE)/$(EFI_ARCH)/
 DEBUGINFO	?= $(prefix)/lib/debug/
 DEBUGSOURCE	?= $(prefix)/src/debug/
 OSLABEL		?= $(EFIDIR)
-DEFAULT_LOADER	?= \\\\grub$(EFI_ARCH_SUFFIX).efi
+DEFAULT_LOADER	?= \\\\\\\\grub$(EFI_ARCH_SUFFIX).efi
 DASHJ		?= -j$(shell echo $$(($$(grep -c "^model name" /proc/cpuinfo) + 1)))
 OPTIMIZATIONS	?= -Os
 


### PR DESCRIPTION
Shim currently fails to build with these errors when DEFAULT_LOADER isn't provided:

 .././src/shim.c: In function ‘set_second_stage’:
 .././src/shim.c:2099:28: error: unknown escape sequence: '\g' [-Werror]
  2099 |  second_stage_len = StrLen(DEFAULT_LOADER) + 1;
       |                            ^~~~~~~~~~~~~~
 .././src/shim.c:2105:23: error: unknown escape sequence: '\g' [-Werror]
  2105 |  StrCpy(second_stage, DEFAULT_LOADER);
       |                       ^~~~~~~~~~~~~~
 .././src/netboot.c: In function ‘extract_tftp_info’:
 .././src/netboot.c:192:24: error: unknown escape sequence: '\g' [-Werror]
   192 |  CHAR8 template[sizeof DEFAULT_LOADER_CHAR];
       |                        ^~~~~~~~~~~~~~~~~~~
 .././src/netboot.c:194:30: error: unknown escape sequence: '\g' [-Werror]
   194 |  translate_slashes(template, DEFAULT_LOADER_CHAR);
       |                              ^~~~~~~~~~~~~~~~~~~
 .././src/netboot.c: In function ‘parseDhcp4’:
 .././src/netboot.c:259:24: error: unknown escape sequence: '\g' [-Werror]
   259 |  CHAR8 template[sizeof DEFAULT_LOADER_CHAR];
       |                        ^~~~~~~~~~~~~~~~~~~
 .././src/netboot.c:264:30: error: unknown escape sequence: '\g' [-Werror]
   264 |  translate_slashes(template, DEFAULT_LOADER_CHAR);
       |                              ^~~~~~~~~~~~~~~~~~~

This is because of the following define in <builddir>/src/config.h:

 #define DEFAULT_LOADER L"\\grubx64.efi"

DEFAULT_LOADER is set in include/defaults.mk:

 DEFAULT_LOADER	?= \\\\\\\\grub$(EFI_ARCH_SUFFIX).efi

This is escaped to "\\\\grubx64.efi", and it is then echo'd to config.h
where it is further escaped by the shell to "\\grubx64.efi".