### PR TITLE
Fix sbsign command usage

### DIFF
--- a/include/defaults.mk
+++ b/include/defaults.mk
@@ -86,7 +86,7 @@ ifneq ($(origin ENABLE_SBSIGN),undefined)
 	@$(SBSIGN) \
 		--key $(BUILDDIR)/certdb/shim.key \
 		--cert $(BUILDDIR)/certdb/shim.crt \
-		--output $(BUILDDIR)/$@ $(BUILDDIR)/$^
+		--output $(BUILDDIR)/$@ $(BUILDDIR)/$<
 else
 .ONESHELL: $(MMNAME).signed $(FBNAME).signed
 %.efi.signed: %.efi certdb/secmod.db


### PR DESCRIPTION
The previous make target was passing all of the target's prerequisites
as boot images to sbsign, causing it to fail.