### PR TITLE
Include missing .text sections in PE/COFF binary

### DIFF
--- a/include/elf_x64_efi.lds
+++ b/include/elf_x64_efi.lds
@@ -15,6 +15,8 @@ SECTIONS
   {
     _text = .;
     *(.text)
+    *(.text.startup)
+    *(.text.unlikely)
     _etext = .;
   }
 


### PR DESCRIPTION
At the default -Os optimization level, gcc emits ".text.startup"
and ".text.unlikely" sections for static initializers and noreturn
functions which end up in the intermediate ELF binary:

```
$ objdump -h build-x64/shimx64.efi.so

build-x64/shimx64.efi.so:     file format elf64-x86-64

Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .text         00046e7b  0000000000001000  0000000000001000  00001000  2**10
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .text.startup 00000118  0000000000047e7b  0000000000047e7b  00047e7b  2**0
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  2 .text.unlikely 00000046  0000000000047f93  0000000000047f93  00047f93  2**0
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  3 .data         000315e8  0000000000048000  0000000000048000  00048000  2**9
```

These additional .text.* sections are omitted from the final PE/COFF
binary, resulting in a crash when processing the ctors. Taking a look at
_init_array in gdb:

```
(gdb) p/x &_init_array
$1 = 0x78510
(gdb) p/x &_init_array_end
$2 = 0x7851c
(gdb) x/x (void*)&_init_array
0x78510 <_init_array>:  0x00047e7b
(gdb) x/x (void*)(&_init_array)+8
0x78518 <_init_array+8>:  0x00000000
```

See that 0x00047e7b falls inside the padding between the .text and .data
sections:

```
$ objdump -h build-x64/shimx64.efi

build-x64/shimx64.efi:     file format pei-x86-64

Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .text         00046e7b  0000000000001000  0000000000001000  00000400  2**10
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .data         000315e8  0000000000048000  0000000000048000  00047400  2**9
```

Adjust the linker script to merge the .text.startup and .text.unlikely
sections in to the .text section.