### PR TITLE
Fix buffer overrun due DEFAULT_LOADER length miscalculation

### DIFF
--- a/src/shim.c
+++ b/src/shim.c
@@ -2096,7 +2096,7 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 	unsigned int i;
 	UINTN second_stage_len;
 
-	second_stage_len = StrLen(DEFAULT_LOADER) + 1;
+	second_stage_len = (StrLen(DEFAULT_LOADER) + 1) * sizeof(CHAR16);
 	second_stage = AllocatePool(second_stage_len);
 	if (!second_stage) {
 		perror(L"Could not allocate %lu bytes\n", second_stage_len);


### PR DESCRIPTION
The DEFAULT_LOADER is a UCS-2 string and the StrLen() function returns the
number of UCS-2 encoded characters in the string. But the allocated memory
is in bytes, so only half of the needed memory to store it is allocated.

This leads to a buffer overrun when the StrCpy() function attempts to copy
the DEFAULT_LOADER to the allocated buffer.

Fixes: 354bd9b1931 ("Actually check for errors from set_second_stage()")
Reported-by: Stuart Hayes <stuart_hayes@dell.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>