### PR TITLE
BUG: add some basic $EFI_PATH checking

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -108,7 +108,7 @@ endif
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)
-EFI_PATH	?= $(LIBDIR)/gnuefi
+EFI_PATH	?= $(shell [ -d $(LIBDIR)/gnuefi ] && echo "$(LIBDIR)/gnuefi" || echo "$(LIBDIR)")
 
 MMSTEM		?= mm$(ARCH_SUFFIX)
 MMNAME		= $(MMSTEM).efi


### PR DESCRIPTION
Not all distributions put the crt0-efi-$(ARCH).o file under
$LIB_DIR/gnuefi, some stash it directly in $LIB_DIR.  In an effort
to make the build a bit more user friendly, check if $LIB_DIR/gnuefi
exits before setting $EFI_PATH to that value; if $LIB_DIR/gnuefi does
not exist, fallback to $LIB_DIR for $EFI_PATH.

Signed-off-by: Paul Moore <pmoore2@cisco.com>