### PR TITLE
RFE: load local build configuration from Make.local if present

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Make.local
 .*.sw?
 certdb
 shim_cert.h

--- a/Make.defaults
+++ b/Make.defaults
@@ -1,3 +1,7 @@
+
+# load the local configuration if it exists
+-include Make.local
+
 COMPILER	?= gcc
 CC		= $(CROSS_COMPILE)$(COMPILER)
 LD		= $(CROSS_COMPILE)ld


### PR DESCRIPTION
If the file Make.local exists, use it as a source of local build
configuration by including it in Make.defaults.

Signed-off-by: Paul Moore <pmoore2@cisco.com>