### PR TITLE
RFE: support a stable PCR across firmware updates, enable booting a kernel directly

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -109,6 +109,10 @@ ifneq ($(origin ENABLE_PCR8_SIGNER), undefined)
 	CFLAGS  += -DENABLE_PCR8_SIGNER
 endif
 
+ifneq ($(origin ENABLE_PCR9_LOADER), undefined)
+	CFLAGS  += -DENABLE_PCR9_LOADER
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)

--- a/Make.defaults
+++ b/Make.defaults
@@ -105,6 +105,10 @@ ifneq ($(origin REQUIRE_TPM), undefined)
 	CFLAGS  += -DREQUIRE_TPM
 endif
 
+ifneq ($(origin ENABLE_PCR8_SIGNER), undefined)
+	CFLAGS  += -DENABLE_PCR8_SIGNER
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)

--- a/Make.defaults
+++ b/Make.defaults
@@ -113,6 +113,10 @@ ifneq ($(origin ENABLE_PCR9_LOADER), undefined)
 	CFLAGS  += -DENABLE_PCR9_LOADER
 endif
 
+ifneq ($(origin DISABLE_EBS), undefined)
+	CFLAGS  += -DDISABLE_EBS
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)

--- a/README.tpm
+++ b/README.tpm
@@ -21,6 +21,9 @@ PCR7:
   "MokSBState".
 
 PCR8:
+- If you've built shim with ENABLE_PCR8_SIGNER the "SecureBoot", "PK",
+  "KEK", and signing certificate (if used) of the second stage loader are
+  extended into PCR8.
 - If you're using the grub2 TPM patchset we cary in Fedora, the kernel command
   line and all grub commands (including all of grub.cfg that gets run) are
   measured into PCR8.

--- a/README.tpm
+++ b/README.tpm
@@ -29,6 +29,8 @@ PCR8:
   measured into PCR8.
   
 PCR9:
+- If you've built shim with ENABLE_PCR9_LOADER the SHA256 hash of the loader
+  and the original, non-hashed loader options are extended into PCR9.
 - If you're using the grub2 TPM patchset we carry in Fedora, the kernel,
   initramfs, and any multiboot modules loaded are measured into PCR9.
 

--- a/include/tpm.h
+++ b/include/tpm.h
@@ -19,6 +19,9 @@ EFI_STATUS tpm_measure_variable(CHAR16 *dbname, EFI_GUID guid, UINTN size, void 
 EFI_STATUS tpm_measure_signer(CHAR16 *Name, EFI_GUID VendorGuid,
 			      UINTN Size, VOID *Data);
 
+EFI_STATUS tpm_measure_loader(UINT8 *digest, UINT32 digest_size,
+			      UINT8 *options, UINT32 options_size);
+
 typedef struct {
   uint8_t Major;
   uint8_t Minor;

--- a/include/tpm.h
+++ b/include/tpm.h
@@ -16,6 +16,9 @@ EFI_STATUS tpm_log_pe(EFI_PHYSICAL_ADDRESS buf, UINTN size,
 
 EFI_STATUS tpm_measure_variable(CHAR16 *dbname, EFI_GUID guid, UINTN size, void *data);
 
+EFI_STATUS tpm_measure_signer(CHAR16 *Name, EFI_GUID VendorGuid,
+			      UINTN Size, VOID *Data);
+
 typedef struct {
   uint8_t Major;
   uint8_t Minor;

--- a/replacements.c
+++ b/replacements.c
@@ -131,6 +131,7 @@ replacement_start_image(EFI_HANDLE image_handle, UINTN *exit_data_size, CHAR16 *
 	return efi_status;
 }
 
+#if !defined(DISABLE_EBS)
 static EFI_STATUS EFIAPI
 exit_boot_services(EFI_HANDLE image_key, UINTN map_key)
 {
@@ -150,6 +151,7 @@ exit_boot_services(EFI_HANDLE image_key, UINTN map_key)
 	gRT->ResetSystem(EfiResetShutdown, EFI_SECURITY_VIOLATION, 0, NULL);
 	return EFI_SECURITY_VIOLATION;
 }
+#endif /* !defined(DISABLE_EBS) */
 
 static EFI_STATUS EFIAPI
 do_exit(EFI_HANDLE ImageHandle, EFI_STATUS ExitStatus,
@@ -199,17 +201,22 @@ hook_system_services(EFI_SYSTEM_TABLE *local_systab)
 	system_start_image = systab->BootServices->StartImage;
 	systab->BootServices->StartImage = replacement_start_image;
 
+#if !defined(DISABLE_EBS)
 	/* we need to hook ExitBootServices() so a) we can enforce the policy
 	 * and b) we can unwrap when we're done. */
 	system_exit_boot_services = systab->BootServices->ExitBootServices;
 	systab->BootServices->ExitBootServices = exit_boot_services;
+#endif /* defined(DISABLE_EBS) */
 }
 
 void
 unhook_exit(void)
 {
+#if !defined(DISABLE_EBS)
 	systab->BootServices->Exit = system_exit;
 	gBS = systab->BootServices;
+#endif /* defined(DISABLE_EBS) */
+	return;
 }
 
 void


### PR DESCRIPTION
This PR is focused on creating a PCR which measures the kernel's signing authority while remaining stable across firmware updates.  While PCR7 is close to what we need, it measures the `db` and `dbx` variables which can change during a firmware update.  As noted in one of the patch descriptions:

    The problem is that PCR7 measures the db and dbx variables which can
    change during a UEFI/firmware update as new values are added, moved,
    and removed.  For those use cases which require PCR stability across
    firmware updates, we need a different solution.
    
    This patch attempts to satisfy this need by extending PCR8 in a
    similar manner, measuring most of what is measured into PCR7 but not
    the db and dbx variables.  PCR8 is extended with the SecureBoot, PK,
    KEK, and the db certificate that authorized the second stage loader.
    While the db and dbx variables are not measured, measuring the PK
    and KEK helps ensure that db and dbx updates (if any) have been
    authorized.

Using PCR8 is not without its challenges, the largest being that the GRUB2 which ships with most Linux distributions makes use of PC8 (and PCR9 for that matter).  If we are to leverage PCR8 we need to do so without GRUB2, or at least without a GRUB2 build that extends PCR8.  Thankfully UEFI provides its own bootloader functionality which is sufficient for many systems.  The only drawback to booting a Linux Kernel directly from shim is the `ExitBootServices()` hook which requires that the second stage loader (or kernel in the case described here) calls into the shim verification protocol.  However, in our case we can safely skip this check:

    On systems where a second stage bootloader is not used, and the Linux
    Kernel is booted directly from shim, shim's ExitBootServices() hook
    can cause problems as the kernel never calls the shim's verification
    protocol.  In this case calling the shim verification protocol is
    unnecessary and redundant as shim has already verified the kernel
    when shim loaded the kernel as the second stage loader.

The concepts in this PR were discussed, albeit briefly, on the EFI mailing list at the link below:

* https://lists.einval.com/pipermail/efi/2020-October/000011.html