### PR TITLE
fix EV_EFI_VARIABLE_AUTHORITY event in eventlog

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -450,7 +450,7 @@ static CHECK_STATUS check_db_cert_in_ram(EFI_SIGNATURE_LIST *CertList,
 								      hash, SHA256_DIGEST_SIZE);
 					if (IsFound) {
 						dprint(L"AuthenticodeVerify() succeeded: %d\n", IsFound);
-						tpm_measure_variable(dbname, guid, CertSize, Cert->SignatureData);
+						tpm_measure_variable(dbname, guid, CertList->SignatureSize, Cert);
 						drain_openssl_errors();
 						return DATA_FOUND;
 					} else {
@@ -515,7 +515,7 @@ static CHECK_STATUS check_db_hash_in_ram(EFI_SIGNATURE_LIST *CertList,
 					// Find the signature in database.
 					//
 					IsFound = TRUE;
-					tpm_measure_variable(dbname, guid, SignatureSize, data);
+					tpm_measure_variable(dbname, guid, CertList->SignatureSize, Cert);
 					break;
 				}
 


### PR DESCRIPTION
Currently, for an EV_EFI_VARIABLE_AUTHORITY event, the shim puts only EFI_SIGNATURE_DATA.SignatureData in the VariableData field, but omits EFI_SIGNATURE_DATA.SignatureOwner. According to reference implementation in EDK2, the entire EFI_SIGNATURE_DATA is put into the VariableData field, shown here:
https://github.com/tianocore/edk2/blob/master/SecurityPkg/Library/DxeImageVerificationLib/DxeImageVerificationLib.c#L1032