### PR TITLE
RFE: compile time option to bypass the ExitBootServices() check

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -105,6 +105,10 @@ ifneq ($(origin REQUIRE_TPM), undefined)
 	CFLAGS  += -DREQUIRE_TPM
 endif
 
+ifneq ($(origin DISABLE_EBS), undefined)
+	CFLAGS  += -DDISABLE_EBS
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)

--- a/replacements.c
+++ b/replacements.c
@@ -131,6 +131,7 @@ replacement_start_image(EFI_HANDLE image_handle, UINTN *exit_data_size, CHAR16 *
 	return efi_status;
 }
 
+#if !defined(DISABLE_EBS)
 static EFI_STATUS EFIAPI
 exit_boot_services(EFI_HANDLE image_key, UINTN map_key)
 {
@@ -150,6 +151,7 @@ exit_boot_services(EFI_HANDLE image_key, UINTN map_key)
 	gRT->ResetSystem(EfiResetShutdown, EFI_SECURITY_VIOLATION, 0, NULL);
 	return EFI_SECURITY_VIOLATION;
 }
+#endif /* !defined(DISABLE_EBS) */
 
 static EFI_STATUS EFIAPI
 do_exit(EFI_HANDLE ImageHandle, EFI_STATUS ExitStatus,
@@ -199,17 +201,22 @@ hook_system_services(EFI_SYSTEM_TABLE *local_systab)
 	system_start_image = systab->BootServices->StartImage;
 	systab->BootServices->StartImage = replacement_start_image;
 
+#if !defined(DISABLE_EBS)
 	/* we need to hook ExitBootServices() so a) we can enforce the policy
 	 * and b) we can unwrap when we're done. */
 	system_exit_boot_services = systab->BootServices->ExitBootServices;
 	systab->BootServices->ExitBootServices = exit_boot_services;
+#endif /* defined(DISABLE_EBS) */
 }
 
 void
 unhook_exit(void)
 {
+#if !defined(DISABLE_EBS)
 	systab->BootServices->Exit = system_exit;
 	gBS = systab->BootServices;
+#endif /* defined(DISABLE_EBS) */
+	return;
 }
 
 void


### PR DESCRIPTION
On systems where a second stage bootloader is not used, and the Linux Kernel is booted directly from shim, shim's ExitBootServices() hook can cause problems as the kernel never calls the shim's verification protocol.  In this case calling the shim verification protocol is unnecessary and redundant as shim has already verified the kernel when shim loaded the kernel as the second stage loader.

This functionality is disabled by default and must be enabled via the DISABLE_EBS macro/define at build time.

Signed-off-by: Paul Moore <pmoore2@cisco.com>