### PR TITLE
Add a .sbat section to EFI binaries

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -22,6 +22,7 @@ DEBUGSOURCE	?= $(prefix)/src/debug/
 OSLABEL		?= $(EFIDIR)
 DEFAULT_LOADER	?= \\\\grub$(ARCH_SUFFIX).efi
 DASHJ		?= -j$(shell echo $$(($$(grep -c "^model name" /proc/cpuinfo) + 1)))
+SBATPATH	?= data/sbat.csv
 
 ARCH		?= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
 OBJCOPY_GTE224	= $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.*\((.*)\|version\) //g' | cut -f1-2 -d.` \>= 2.24)

--- a/data/sbat.csv
+++ b/data/sbat.csv
@@ -1,0 +1,2 @@
+sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
+shim,0,UEFI shim,shim,0,https://github.com/rhboot/shim

--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -58,7 +58,12 @@ SECTIONS
     *(.vendor_cert)
   }
   . = ALIGN(4096);
-
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    _esbat = .;
+  }
   . = ALIGN(4096);
   .rela :
   {

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -56,7 +56,12 @@ SECTIONS
     *(.vendor_cert)
   }
   . = ALIGN(4096);
-
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    _esbat = .;
+  }
   . = ALIGN(4096);
   .rel :
   {

--- a/elf_ia32_efi.lds
+++ b/elf_ia32_efi.lds
@@ -54,6 +54,13 @@ SECTIONS
    *(.vendor_cert)
   }
   . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    _esbat = .;
+  }
+  . = ALIGN(4096);
   .dynamic  : { *(.dynamic) }
   . = ALIGN(4096);
   .rel :

--- a/elf_ia64_efi.lds
+++ b/elf_ia64_efi.lds
@@ -56,6 +56,13 @@ SECTIONS
    *(.vendor_cert)
   }
   . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    _esbat = .;
+  }
+  . = ALIGN(4096);
   .dynamic  : { *(.dynamic) }
   . = ALIGN(4096);
   .rela :

--- a/elf_x86_64_efi.lds
+++ b/elf_x86_64_efi.lds
@@ -59,6 +59,13 @@ SECTIONS
    *(.vendor_cert)
   }
   . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    _esbat = .;
+  }
+  . = ALIGN(4096);
   .dynamic  : { *(.dynamic) }
   . = ALIGN(4096);
   .rela :


### PR DESCRIPTION
The Secure Boot Advanced Targeting (SBAT) [0] is a Generation Number Based
Revocation mechanism that is meant to replace the DBX revocation file list.

Binaries must contain a .sbat data section that has a set entries, each of
them consisting of UTF-8 strings as comma separated values. Allow to embed
this information into the fwupd EFI binary at build time.

The SBAT metadata must contain at least two entries. One that defines the
SBAT version used and another one that defines the component generation.

Downstream users can add additional entries if have changes that make them
diverge from the upstream code and potentially add other vulnerabilities.

The reason why an intermediate step is needed, is because the objcopy tool
only has support for pei-x86_64 and pei-i386 targets. So the .sbat section
has to be added to the ELF shared objects instead of the PE32+ binaries.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>