### PR TITLE
efi bins: add an easy way for vendors to add .sbat data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ shim_cert.h
 version.c
 cov-int/
 scan-results/
+/sbat.*.csv

--- a/BUILDING
+++ b/BUILDING
@@ -60,4 +60,10 @@ Variables you could set to customize the build:
   This is the label that will be put in BOOT$(EFI_ARCH).CSV for your OS.
   By default this is the same value as EFIDIR .
 
+Vendor SBAT data:
+It will sometimes be requested by reviewers that a build includes extra
+.sbat data.  The mechanism to do so is to add a CSV file in data/ with the
+name sbat.FOO.csv, where foo is your EFI subdirectory name.  The build
+system will automatically include any such files.
+
 # vim:filetype=mail:tw=74

--- a/Make.defaults
+++ b/Make.defaults
@@ -2,6 +2,8 @@ COMPILER	?= gcc
 CC		= $(CROSS_COMPILE)$(COMPILER)
 LD		= $(CROSS_COMPILE)ld
 OBJCOPY		= $(CROSS_COMPILE)objcopy
+DOS2UNIX	?= dos2unix
+D2UFLAGS	?= -r -l -F -f -n
 OPENSSL		?= openssl
 HEXDUMP		?= hexdump
 INSTALL		?= install
@@ -22,7 +24,6 @@ DEBUGSOURCE	?= $(prefix)/src/debug/
 OSLABEL		?= $(EFIDIR)
 DEFAULT_LOADER	?= \\\\grub$(ARCH_SUFFIX).efi
 DASHJ		?= -j$(shell echo $$(($$(grep -c "^model name" /proc/cpuinfo) + 1)))
-SBATPATH	?= data/sbat.csv
 
 ARCH		?= $(shell $(CC) -dumpmachine | cut -f1 -d- | sed s,i[3456789]86,ia32,)
 OBJCOPY_GTE224	= $(shell expr `$(OBJCOPY) --version |grep ^"GNU objcopy" | sed 's/^.*\((.*)\|version\) //g' | cut -f1-2 -d.` \>= 2.24)

--- a/Make.rules
+++ b/Make.rules
@@ -1,3 +1,8 @@
 define get-config
 $(shell git config --local --get "shim.$(1)")
 endef
+
+define add-vendor-sbat
+$(OBJCOPY) --add-section ".$(patsubst %.csv,%,$(1))=$(1)" $(2)
+
+endef

--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -62,6 +62,7 @@ SECTIONS
   {
     _sbat = .;
     *(.sbat)
+    *(.sbat.*)
     _esbat = .;
   }
   . = ALIGN(4096);

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -60,6 +60,7 @@ SECTIONS
   {
     _sbat = .;
     *(.sbat)
+    *(.sbat.*)
     _esbat = .;
   }
   . = ALIGN(4096);

--- a/elf_ia32_efi.lds
+++ b/elf_ia32_efi.lds
@@ -58,6 +58,7 @@ SECTIONS
   {
     _sbat = .;
     *(.sbat)
+    *(.sbat.*)
     _esbat = .;
   }
   . = ALIGN(4096);

--- a/elf_ia64_efi.lds
+++ b/elf_ia64_efi.lds
@@ -60,6 +60,7 @@ SECTIONS
   {
     _sbat = .;
     *(.sbat)
+    *(.sbat.*)
     _esbat = .;
   }
   . = ALIGN(4096);

--- a/elf_x86_64_efi.lds
+++ b/elf_x86_64_efi.lds
@@ -63,6 +63,7 @@ SECTIONS
   {
     _sbat = .;
     *(.sbat)
+    *(.sbat.*)
     _esbat = .;
   }
   . = ALIGN(4096);


### PR DESCRIPTION
In cases where we accept vendor shim binaries with additional patches,
it may become necessary to identify those builds with additional SBAT
data.  When we consider such patches, we should be proactive in asking
vendors to include that data in the .sbat sections of their trusted EFI
binaries.

This patch adds any data in data/sbat.*.csv (after a quick sanitizing
pass) after data/sbat.csv in the .sbat section, so  that no changes to
the upstream data/sbat.csv are ever required.

Signed-off-by: Peter Jones <pjones@redhat.com>