### PR TITLE
get_variable: always allocate a NUL character at the end.

### DIFF
--- a/lib/variables.c
+++ b/lib/variables.c
@@ -245,7 +245,11 @@ get_variable_attr(CHAR16 *var, UINT8 **data, UINTN *len, EFI_GUID owner,
 		return efi_status;
 	}
 
-	*data = AllocateZeroPool(*len);
+	/*
+	 * Add three zero pad bytes; at least one correctly aligned UCS-2
+	 * character.
+	 */
+	*data = AllocateZeroPool(*len + 3);
 	if (!*data)
 		return EFI_OUT_OF_RESOURCES;
 
@@ -254,6 +258,7 @@ get_variable_attr(CHAR16 *var, UINT8 **data, UINTN *len, EFI_GUID owner,
 		FreePool(*data);
 		*data = NULL;
 	}
+
 	return efi_status;
 }
 


### PR DESCRIPTION
Sometimes we're loading structures that are parsed in string-like ways,
but can't necessarily be trusted to be zero-terminated.  Solve that by
making sure we always have enough aligned, trailing zero bytes to always
have at least one NUL character, no matter which character type is being
parsed.

Signed-off-by: Peter Jones <pjones@redhat.com>