### PR TITLE
Allow shim to check it's own .sbat section

### DIFF
--- a/include/pe.h
+++ b/include/pe.h
@@ -15,6 +15,9 @@ read_header(void *data, unsigned int datasize,
 	    PE_COFF_LOADER_IMAGE_CONTEXT *context);
 
 EFI_STATUS
+handle_sbat(char *SBATBase, size_t SBATSize);
+
+EFI_STATUS
 handle_image (void *data, unsigned int datasize,
 	      EFI_LOADED_IMAGE *li,
 	      EFI_IMAGE_ENTRY_POINT *entry_point,

--- a/include/sbat.h
+++ b/include/sbat.h
@@ -25,6 +25,7 @@ struct sbat_entry {
 };
 
 EFI_STATUS parse_sbat(char *sbat_base, size_t sbat_size, size_t *sbats, struct sbat_entry ***sbat);
+void cleanup_sbat_entries(size_t n, struct sbat_entry **entries);
 
 EFI_STATUS verify_sbat(size_t n, struct sbat_entry **entries, list_t *var_entries);
 

--- a/include/sbat.h
+++ b/include/sbat.h
@@ -15,12 +15,7 @@ struct sbat_entry {
 	const CHAR8 *vendor_url;
 };
 
-struct sbat {
-	unsigned int size;
-	struct sbat_entry **entries;
-};
-
-EFI_STATUS parse_sbat(char *sbat_base, size_t sbat_size, struct sbat *sbat);
+EFI_STATUS parse_sbat(char *sbat_base, size_t sbat_size, size_t *sbats, struct sbat_entry ***sbat);
 
 #endif /* !SBAT_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/include/sbat.h
+++ b/include/sbat.h
@@ -11,6 +11,7 @@ struct sbat_var {
 	const CHAR8 *component_generation;
 	list_t list;
 };
+extern list_t sbat_var;
 
 EFI_STATUS parse_sbat_var(list_t *entries);
 void cleanup_sbat_var(list_t *entries);
@@ -27,7 +28,7 @@ struct sbat_entry {
 EFI_STATUS parse_sbat(char *sbat_base, size_t sbat_size, size_t *sbats, struct sbat_entry ***sbat);
 void cleanup_sbat_entries(size_t n, struct sbat_entry **entries);
 
-EFI_STATUS verify_sbat(size_t n, struct sbat_entry **entries, list_t *var_entries);
+EFI_STATUS verify_sbat(size_t n, struct sbat_entry **entries);
 
 #endif /* !SBAT_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/include/sbat.h
+++ b/include/sbat.h
@@ -6,6 +6,8 @@
 #ifndef SBAT_H_
 #define SBAT_H_
 
+extern UINTN _sbat, _esbat;
+
 struct sbat_var {
 	const CHAR8 *component_name;
 	const CHAR8 *component_generation;

--- a/include/sbat.h
+++ b/include/sbat.h
@@ -6,6 +6,15 @@
 #ifndef SBAT_H_
 #define SBAT_H_
 
+struct sbat_var {
+	const CHAR8 *component_name;
+	const CHAR8 *component_generation;
+	list_t list;
+};
+
+EFI_STATUS parse_sbat_var(list_t *entries);
+void cleanup_sbat_var(list_t *entries);
+
 struct sbat_entry {
 	const CHAR8 *component_name;
 	const CHAR8 *component_generation;
@@ -16,6 +25,8 @@ struct sbat_entry {
 };
 
 EFI_STATUS parse_sbat(char *sbat_base, size_t sbat_size, size_t *sbats, struct sbat_entry ***sbat);
+
+EFI_STATUS verify_sbat(size_t n, struct sbat_entry **entries, list_t *var_entries);
 
 #endif /* !SBAT_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/pe.c
+++ b/pe.c
@@ -823,7 +823,7 @@ read_header(void *data, unsigned int datasize,
 	return EFI_SUCCESS;
 }
 
-static EFI_STATUS
+EFI_STATUS
 handle_sbat(char *SBATBase, size_t SBATSize)
 {
 	unsigned int i;

--- a/pe.c
+++ b/pe.c
@@ -1044,6 +1044,8 @@ handle_image (void *data, unsigned int datasize,
 		size_t n;
 		struct sbat_entry **entries;
 		struct sbat_entry *entry = NULL;
+		list_t sbat_var_entries;
+		INIT_LIST_HEAD(&sbat_var_entries);
 
 		if (SBATBase && SBATSize) {
 			char *sbat_data;
@@ -1079,6 +1081,32 @@ handle_image (void *data, unsigned int datasize,
 		} else {
 			perror(L"SBAT data not found\n");
 			return EFI_UNSUPPORTED;
+		}
+
+		efi_status = parse_sbat_var(&sbat_var_entries);
+		/*
+		 * Until a SBAT variable is installed into the systems, it is expected that
+		 * attempting to parse the variable will fail with an EFI_NOT_FOUND error.
+		 *
+		 * Do not consider that error fatal for now.
+		 */
+		if (EFI_ERROR(efi_status) && efi_status != EFI_NOT_FOUND) {
+			perror(L"Parsing SBAT variable failed: %r\n",
+			       efi_status);
+			return efi_status;
+		}
+
+		if (efi_status == EFI_SUCCESS)
+			efi_status = verify_sbat(n, entries, &sbat_var_entries);
+		if (efi_status == EFI_NOT_FOUND)
+			efi_status = EFI_SUCCESS;
+
+		if (EFI_ERROR(efi_status)) {
+			if (verbose)
+				console_print(L"Verification failed: %r\n", efi_status);
+			else
+				console_error(L"Verification failed", efi_status);
+			return efi_status;
 		}
 
 		efi_status = verify_buffer(data, datasize,

--- a/pe.c
+++ b/pe.c
@@ -1041,7 +1041,8 @@ handle_image (void *data, unsigned int datasize,
 	if (secure_mode ()) {
 		unsigned int i;
 		EFI_STATUS efi_status;
-		struct sbat sbat = { 0 };
+		size_t n;
+		struct sbat_entry **entries;
 		struct sbat_entry *entry = NULL;
 
 		if (SBATBase && SBATSize) {
@@ -1057,7 +1058,7 @@ handle_image (void *data, unsigned int datasize,
 			CopyMem(sbat_data, SBATBase, SBATSize);
 			sbat_data[SBATSize] = '\0';
 
-			efi_status = parse_sbat(sbat_data, sbat_size, &sbat);
+			efi_status = parse_sbat(sbat_data, sbat_size, &n, &entries);
 			if (EFI_ERROR(efi_status)) {
 				perror(L"SBAT data not correct: %r\n",
 				       efi_status);
@@ -1065,8 +1066,8 @@ handle_image (void *data, unsigned int datasize,
 			}
 
 			dprint(L"SBAT data\n");
-			for (i = 0; i < sbat.size; i++) {
-				entry = sbat.entries[i];
+			for (i = 0; i < n; i++) {
+				entry = entries[i];
 				dprint(L"%a, %a, %a, %a, %a, %a\n",
 				       entry->component_name,
 				       entry->component_generation,
@@ -1083,9 +1084,9 @@ handle_image (void *data, unsigned int datasize,
 		efi_status = verify_buffer(data, datasize,
 					   &context, sha256hash, sha1hash);
 
-		if (sbat.entries)
-			for (i = 0; i < sbat.size; i++)
-				FreePool(sbat.entries[i]);
+		if (entries)
+			for (i = 0; i < n; i++)
+				FreePool(entries[i]);
 
 		if (EFI_ERROR(efi_status)) {
 			if (verbose)

--- a/sbat.c
+++ b/sbat.c
@@ -194,20 +194,20 @@ cleanup_sbat_var(list_t *entries)
 }
 
 EFI_STATUS
-verify_sbat(size_t n, struct sbat_entry **entries, list_t *sbat_entries)
+verify_sbat(size_t n, struct sbat_entry **entries)
 {
 	unsigned int i;
 	list_t *pos = NULL;
 	EFI_STATUS efi_status = EFI_SUCCESS;
 	struct sbat_var *sbat_var_entry;
 
-	if (!entries || list_empty(sbat_entries)) {
-		dprint(L"SBAT variable not present or malformed\n");
-		return EFI_INVALID_PARAMETER;
+	if (list_empty(&sbat_var)) {
+		dprint(L"SBAT variable not present\n");
+		return EFI_SUCCESS;
 	}
 
 	for (i = 0; i < n; i++) {
-		list_for_each(pos, sbat_entries) {
+		list_for_each(pos, &sbat_var) {
 			sbat_var_entry = list_entry(pos, struct sbat_var, list);
 			efi_status = verify_single_entry(entries[i], sbat_var_entry);
 			if (EFI_ERROR(efi_status))
@@ -216,7 +216,6 @@ verify_sbat(size_t n, struct sbat_entry **entries, list_t *sbat_entries)
 	}
 
 	dprint(L"all entries from SBAT section verified\n");
-	cleanup_sbat_var(sbat_entries);
 	return efi_status;
 }
 

--- a/sbat.c
+++ b/sbat.c
@@ -4,6 +4,7 @@
  */
 
 #include "shim.h"
+#include "string.h"
 
 CHAR8 *
 get_sbat_field(CHAR8 *current, CHAR8 *end, const CHAR8 **field, char delim)
@@ -70,8 +71,8 @@ error:
 EFI_STATUS
 parse_sbat(char *sbat_base, size_t sbat_size, size_t *sbats, struct sbat_entry ***sbat)
 {
-	CHAR8 *current = (CHAR8 *) sbat_base;
-	CHAR8 *end = (CHAR8 *) sbat_base + sbat_size - 1;
+	CHAR8 *current = (CHAR8 *)sbat_base;
+	CHAR8 *end = (CHAR8 *)sbat_base + sbat_size - 1;
 	EFI_STATUS efi_status = EFI_SUCCESS;
 	struct sbat_entry *entry;
 	struct sbat_entry **entries = NULL;
@@ -121,4 +122,191 @@ error:
 	return efi_status;
 }
 
+EFI_STATUS
+verify_single_entry(struct sbat_entry *entry, struct sbat_var *sbat_var_entry)
+{
+	UINT16 sbat_gen, sbat_var_gen;
+
+	if (strcmp(entry->component_name, sbat_var_entry->component_name) == 0) {
+		dprint(L"component %a has a matching SBAT variable entry, verifying\n",
+			entry->component_name);
+
+		/*
+		 * atoi returns zero for failed conversion, so essentially
+		 * badly parsed component_generation will be treated as zero
+		 */
+		sbat_gen = atoi(entry->component_generation);
+		sbat_var_gen = atoi(sbat_var_entry->component_generation);
+
+		if (sbat_gen < sbat_var_gen) {
+			dprint(L"component %a, generation %d, was revoked by SBAT variable",
+			       entry->component_name, sbat_gen);
+			LogError(L"image did not pass SBAT verification\n");
+			return EFI_SECURITY_VIOLATION;
+		}
+	}
+	return EFI_SUCCESS;
+}
+
+void
+cleanup_sbat_var(list_t *entries)
+{
+	list_t *pos = NULL, *tmp = NULL;
+	struct sbat_var *entry;
+
+	list_for_each_safe(pos, tmp, entries) {
+		entry = list_entry(pos, struct sbat_var, list);
+		list_del(&entry->list);
+
+		if (entry->component_generation)
+			FreePool((CHAR8 *)entry->component_name);
+		if (entry->component_name)
+			FreePool((CHAR8 *)entry->component_generation);
+		FreePool(entry);
+	}
+}
+
+EFI_STATUS
+verify_sbat(size_t n, struct sbat_entry **entries, list_t *sbat_entries)
+{
+	unsigned int i;
+	list_t *pos = NULL;
+	EFI_STATUS efi_status = EFI_SUCCESS;
+	struct sbat_var *sbat_var_entry;
+
+	if (!entries || list_empty(sbat_entries)) {
+		dprint(L"SBAT variable not present or malformed\n");
+		return EFI_INVALID_PARAMETER;
+	}
+
+	for (i = 0; i < n; i++) {
+		list_for_each(pos, sbat_entries) {
+			sbat_var_entry = list_entry(pos, struct sbat_var, list);
+			efi_status = verify_single_entry(entries[i], sbat_var_entry);
+			if (EFI_ERROR(efi_status))
+				return efi_status;
+		}
+	}
+
+	dprint(L"all entries from SBAT section verified\n");
+	cleanup_sbat_var(sbat_entries);
+	return efi_status;
+}
+
+static BOOLEAN
+is_utf8_bom(CHAR8 *buf, size_t bufsize)
+{
+	unsigned char bom[] = { 0xEF, 0xBB, 0xBF };
+
+	return CompareMem(buf, bom, MIN(sizeof(bom), bufsize)) == 0;
+}
+
+static struct sbat_var *
+new_entry(const CHAR8 *comp_name, const CHAR8 *comp_gen)
+{
+	struct sbat_var *new_entry = AllocatePool(sizeof(*new_entry));
+
+	if (!new_entry)
+		return NULL;
+
+	INIT_LIST_HEAD(&new_entry->list);
+	new_entry->component_name = comp_name;
+	new_entry->component_generation = comp_gen;
+
+	return new_entry;
+}
+
+EFI_STATUS
+add_entry(list_t *list, const CHAR8 *comp_name, const CHAR8 *comp_gen)
+{
+	struct sbat_var *new;
+
+	new = new_entry(comp_name, comp_gen);
+	if (!new)
+		return EFI_OUT_OF_RESOURCES;
+
+	list_add_tail(&new->list, list);
+	return EFI_SUCCESS;
+}
+
+EFI_STATUS
+parse_sbat_var(list_t *entries)
+{
+	UINT8 *data = 0;
+	UINTN datasize, i;
+	EFI_STATUS efi_status;
+	char delim;
+
+	if (!entries)
+		return EFI_INVALID_PARAMETER;
+
+	INIT_LIST_HEAD(entries);
+
+	efi_status = get_variable(L"SBAT", &data, &datasize, SHIM_LOCK_GUID);
+	if (EFI_ERROR(efi_status)) {
+		LogError(L"Failed to read SBAT variable\n",
+			 efi_status);
+		return efi_status;
+	}
+
+	CHAR8 *start = (CHAR8 *)data;
+	CHAR8 *end = (CHAR8 *)data + datasize;
+	if (is_utf8_bom(start, datasize))
+		start += 3;
+
+	dprint(L"SBAT variable data:\n");
+
+	while (start[0] != '\0') {
+		const CHAR8 *fields[2] = {
+			NULL,
+		};
+		for (i = 0; i < 3; i++) {
+			const CHAR8 *tmp;
+			/*
+			 * on third iteration we check if we had extra stuff on line while parsing
+			 * component_name. If delimeter on 2nd iteration was ',', this means that
+			 * we have comments after component_name. get_sbat_field in this if condition
+			 * parses comments, if they are present and drops them.
+			 */
+			if (i == 2 && start) {
+				if (delim == ',') {
+					start = get_sbat_field(start, end, &tmp,
+					                       '\n');
+				}
+				break;
+			}
+			delim = ',';
+			/* we do not want to jump to next line and grab stuff from that
+			 */
+			if ((strchrnula(start, '\n') - start + 1) <=
+			    (strchrnula(start, ',') - start + 1)) {
+				delim = '\n';
+				if (i == 0)
+					goto error;
+			}
+			if (!start) {
+				goto error;
+			}
+			start = get_sbat_field(start, end, &tmp, delim);
+			/*   to be replaced when we have strdupa()
+			 */
+			fields[i] = strndupa(tmp, strlen(tmp));
+			if (!fields[i]) {
+				goto error;
+			}
+		}
+		dprint(L"component %a with generation %a\n", fields[0], fields[1]);
+		efi_status =
+			add_entry(entries, fields[0], fields[1]);
+		if (EFI_ERROR(efi_status))
+			goto error;
+	}
+	FreePool(data);
+	return EFI_SUCCESS;
+error:
+	perror(L"failed to parse SBAT variable\n");
+	cleanup_sbat_var(entries);
+	FreePool(data);
+	return EFI_INVALID_PARAMETER;
+}
 // vim:fenc=utf-8:tw=75:noet

--- a/sbat.c
+++ b/sbat.c
@@ -89,7 +89,7 @@ EFI_STATUS
 parse_sbat(char *sbat_base, size_t sbat_size, size_t *sbats, struct sbat_entry ***sbat)
 {
 	CHAR8 *current = (CHAR8 *)sbat_base;
-	CHAR8 *end = (CHAR8 *)sbat_base + sbat_size - 1;
+	CHAR8 *end = (CHAR8 *)sbat_base + sbat_size;
 	EFI_STATUS efi_status = EFI_SUCCESS;
 	struct sbat_entry *entry = NULL;
 	struct sbat_entry **entries;

--- a/shim.c
+++ b/shim.c
@@ -1909,6 +1909,8 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		goto die;
 	}
 
+	init_openssl();
+
 	/*
 	 * Before we do anything else, validate our non-volatile,
 	 * boot-services-only state variables are what we think they are.

--- a/shim.c
+++ b/shim.c
@@ -1858,12 +1858,14 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		L"import_mok_state() failed",
 		L"shim_init() failed",
 		L"import of SBAT data failed",
+		L"SBAT self-check failed",
 		NULL
 	};
 	enum {
 		IMPORT_MOK_STATE,
 		SHIM_INIT,
 		IMPORT_SBAT,
+		SBAT_SELF_CHECK,
 	} msg = IMPORT_MOK_STATE;
 
 	/*
@@ -1907,6 +1909,19 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		       efi_status);
 		msg = IMPORT_SBAT;
 		goto die;
+	}
+
+	if (secure_mode ()) {
+		char *sbat_start = (char *)&_sbat;
+		char *sbat_end = (char *)&_esbat;
+
+		efi_status = handle_sbat(sbat_start, sbat_end - sbat_start);
+		if (EFI_ERROR(efi_status)) {
+			perror(L"Verifiying shim SBAT data failed: %r\n",
+			       efi_status);
+			msg = SBAT_SELF_CHECK;;
+			goto die;
+		}
 	}
 
 	init_openssl();

--- a/shim.c
+++ b/shim.c
@@ -1855,7 +1855,10 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		L"shim_init() failed",
 		NULL
 	};
-	int msg = 0;
+	enum {
+		IMPORT_MOK_STATE,
+		SHIM_INIT,
+	} msg = IMPORT_MOK_STATE;
 
 	/*
 	 * Set up the shim lock protocol so that grub and MokManager can
@@ -1911,7 +1914,7 @@ die:
 
 	efi_status = shim_init();
 	if (EFI_ERROR(efi_status)) {
-		msg = 1;
+		msg = SHIM_INIT;
 		goto die;
 	}
 


### PR DESCRIPTION
Shim should check if it has been revoked and avoid being executed if that's the case.

This pull-request depends on #274.