### PR TITLE
Fix an off by one in strnlena()

### DIFF
--- a/include/str.h
+++ b/include/str.h
@@ -3,12 +3,11 @@
 #ifndef SHIM_STR_H
 #define SHIM_STR_H
 
-static inline
-__attribute__((unused))
-unsigned long strnlena(const CHAR8 *s, unsigned long n)
+static inline __attribute__((unused)) unsigned long
+strnlena(const CHAR8 *s, unsigned long n)
 {
 	unsigned long i;
-	for (i = 0; i <= n; i++)
+	for (i = 0; i < n; i++)
 		if (s[i] == '\0')
 			break;
 	return i;


### PR DESCRIPTION
I wrote a test case for strnlena() and strndupa() and of course both
were off by one in the opposite directions... Woops.

I manually checked all the callers (including all the callers of strcata) and it looks like they should all handle this gracefully either way, but still, better to be correct.