### PR TITLE
build: Import gnu-efi as a submodule and build against it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gnu-efi"]
+	path = gnu-efi
+	url = https://git.code.sf.net/p/gnu-efi/code

--- a/Make.defaults
+++ b/Make.defaults
@@ -31,7 +31,7 @@ OPTIMIZATIONS	?= -Os
 
 SUBDIRS		= $(TOPDIR)/Cryptlib $(TOPDIR)/lib
 
-EFI_INCLUDE	?= /usr/include/efi
+EFI_INCLUDE	?= $(TOPDIR)/gnu-efi/inc
 EFI_INCLUDES	= -nostdinc -I$(TOPDIR)/Cryptlib -I$(TOPDIR)/Cryptlib/Include \
 		  -I$(EFI_INCLUDE) -I$(EFI_INCLUDE)/$(ARCH) -I$(EFI_INCLUDE)/protocol \
 		  -I$(TOPDIR)/include -iquote $(TOPDIR) -iquote $(shell pwd)
@@ -111,7 +111,7 @@ endif
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)
-EFI_PATH	?= $(shell [ -d $(LIBDIR)/gnuefi ] && echo "$(LIBDIR)/gnuefi" || echo "$(LIBDIR)")
+EFI_PATH	?= gnu-efi/$(ARCH)/gnuefi
 
 MMSTEM		?= mm$(ARCH_SUFFIX)
 MMNAME		= $(MMSTEM).efi

--- a/Makefile
+++ b/Makefile
@@ -102,18 +102,21 @@ $(SHIMNAME) : $(SHIMSONAME)
 $(MMNAME) : $(MMSONAME)
 $(FBNAME) : $(FBSONAME)
 
-$(SHIMSONAME): $(OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a
+$(SHIMSONAME): $(OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a gnu-efi/$(ARCH)/gnuefi/libgnuefi.a
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS)
 
 fallback.o: $(FALLBACK_SRCS)
 
-$(FBSONAME): $(FALLBACK_OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a
+$(FBSONAME): $(FALLBACK_OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a gnu-efi/$(ARCH)/gnuefi/libgnuefi.a
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS)
 
 MokManager.o: $(MOK_SOURCES)
 
-$(MMSONAME): $(MOK_OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a
+$(MMSONAME): $(MOK_OBJS) Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a lib/lib.a gnu-efi/$(ARCH)/gnuefi/libgnuefi.a
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS) lib/lib.a
+
+gnu-efi/$(ARCH)/gnuefi/libgnuefi.a:
+	$(MAKE) -C gnu-efi
 
 Cryptlib/libcryptlib.a:
 	for i in Hash Hmac Cipher Rand Pk Pem SysCall; do mkdir -p Cryptlib/$$i; done
@@ -249,6 +252,7 @@ clean-shim-objs:
 clean: clean-shim-objs
 	$(MAKE) -C Cryptlib -f $(TOPDIR)/Cryptlib/Makefile clean
 	$(MAKE) -C Cryptlib/OpenSSL -f $(TOPDIR)/Cryptlib/OpenSSL/Makefile clean
+	$(MAKE) -C gnu-efi clean
 
 GITTAG = $(VERSION)
 


### PR DESCRIPTION
Shim is rather more friendly with EFI internals than most code, and as a
result can end up making assumptions that are out of step with those made
by gnu-efi. Since both projects are developed independently, and since
distributions are often trying to build versions of shim against whatever
version of gnu-efi they are shipping, this can result in awkward build
failures. The easiest way to handle this is to use a git submodule and
import a known-good version of shim directly into the build tree. Given
static linking, this will also make reproducible builds easier.

Signed-off-by: Matthew Garrett <mjg59@google.com>