### PR TITLE
sbat: fix the gcc warnings

### DIFF
--- a/sbat.c
+++ b/sbat.c
@@ -109,7 +109,7 @@ verify_single_entry(struct sbat_section_entry *entry, struct sbat_var_entry *sba
 {
 	UINT16 sbat_gen, sbat_var_gen;
 
-	if (strcmp(entry->component_name, sbat_var_entry->component_name) == 0) {
+	if (strcmp((const char *)entry->component_name, (const char *)sbat_var_entry->component_name) == 0) {
 		dprint(L"component %a has a matching SBAT variable entry, verifying\n",
 			entry->component_name);
 
@@ -117,8 +117,8 @@ verify_single_entry(struct sbat_section_entry *entry, struct sbat_var_entry *sba
 		 * atoi returns zero for failed conversion, so essentially
 		 * badly parsed component_generation will be treated as zero
 		 */
-		sbat_gen = atoi(entry->component_generation);
-		sbat_var_gen = atoi(sbat_var_entry->component_generation);
+		sbat_gen = atoi((const char *)entry->component_generation);
+		sbat_var_gen = atoi((const char *)sbat_var_entry->component_generation);
 
 		if (sbat_gen < sbat_var_gen) {
 			dprint(L"component %a, generation %d, was revoked by SBAT variable",


### PR DESCRIPTION
This commit fixes the following gcc warnings for casting and
uninitialized variable.

 sbat.c: In function 'verify_single_entry':
 sbat.c:157:13: error: pointer targets in passing argument 1 of 'strcmp' differ in signedness [-Werror=pointer-sign]
   if (strcmp(entry->component_name, sbat_var_entry->component_name) == 0) {
              ^~~~~
 In file included from Cryptlib/Include/string.h:15:0,
                  from sbat.c:7:
 Cryptlib/Include/OpenSslSupport.h:299:16: note: expected 'const char *' but argument is of type 'const CHAR8 * {aka const unsigned char *}'
  int            strcmp      (const char *, const char *);
                 ^~~~~~
 sbat.c:157:36: error: pointer targets in passing argument 2 of 'strcmp' differ in signedness [-Werror=pointer-sign]
   if (strcmp(entry->component_name, sbat_var_entry->component_name) == 0) {
                                     ^~~~~~~~~~~~~~
 In file included from Cryptlib/Include/string.h:15:0,
                  from sbat.c:7:
 Cryptlib/Include/OpenSslSupport.h:299:16: note: expected 'const char *' but argument is of type 'const CHAR8 * {aka const unsigned char *}'
  int            strcmp      (const char *, const char *);
                 ^~~~~~
 sbat.c:165:19: error: pointer targets in passing argument 1 of 'AsciiStrDecimalToUintn' differ in signedness [-Werror=pointer-sign]
    sbat_gen = atoi(entry->component_generation);
                    ^
 Cryptlib/Include/OpenSslSupport.h:380:66: note: in definition of macro 'atoi'
  #define atoi(nptr)                        AsciiStrDecimalToUintn(nptr)
                                                                   ^~~~
 In file included from Cryptlib/Include/OpenSslSupport.h:21:0,
                  from Cryptlib/Include/string.h:15,
                  from sbat.c:7:
 Cryptlib/Library/BaseLib.h:9:7: note: expected 'const char *' but argument is of type 'const CHAR8 * {aka const unsigned char *}'
  UINTN AsciiStrDecimalToUintn(const char *String);
        ^~~~~~~~~~~~~~~~~~~~~~
 In file included from Cryptlib/Include/string.h:15:0,
                  from sbat.c:7:
 sbat.c:166:23: error: pointer targets in passing argument 1 of 'AsciiStrDecimalToUintn' differ in signedness [-Werror=pointer-sign]
    sbat_var_gen = atoi(sbat_var_entry->component_generation);
                        ^
 Cryptlib/Include/OpenSslSupport.h:380:66: note: in definition of macro 'atoi'
  #define atoi(nptr)                        AsciiStrDecimalToUintn(nptr)
                                                                   ^~~~
 In file included from Cryptlib/Include/OpenSslSupport.h:21:0,
                  from Cryptlib/Include/string.h:15,
                  from sbat.c:7:
 Cryptlib/Library/BaseLib.h:9:7: note: expected 'const char *' but argument is of type 'const CHAR8 * {aka const unsigned char *}'
  UINTN AsciiStrDecimalToUintn(const char *String);
        ^~~~~~~~~~~~~~~~~~~~~~
 sbat.c: In function 'parse_sbat_var':
 sbat.c:298:8: error: 'delim' may be used uninitialized in this function [-Werror=maybe-uninitialized]
      if (delim == ',') {
         ^
 cc1: all warnings being treated as errors
 make: *** [<builtin>: sbat.o] Error 1

Signed-off-by: Gary Lin <glin@suse.com>