### PR TITLE
Fix two errant 'shim,0' outdated sbat cases.

### DIFF
--- a/SBAT.md
+++ b/SBAT.md
@@ -323,7 +323,7 @@ At the same time, we're all shipping the same `shim-16` codebase, and in our
 `shim` builds, we all have the following in `.sbat`:
 ```
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-shim,0,UEFI shim,shim,16,https://github.com/rhboot/shim
+shim,1,UEFI shim,shim,16,https://github.com/rhboot/shim
 ```
 
 How to add .sbat sections

--- a/data/sbat.csv
+++ b/data/sbat.csv
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-shim,0,UEFI shim,shim,0,https://github.com/rhboot/shim
+shim,1,UEFI shim,shim,1,https://github.com/rhboot/shim


### PR DESCRIPTION
Two places we missed still have 0 for an sbat version - one doc and one
in our data csv.

This fixes those.

Signed-off-by: Peter Jones <pjones@redhat.com>