### PR TITLE
sbat: fix the residual "resource section" for SBAT

### DIFF
--- a/include/sbat.h
+++ b/include/sbat.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 /*
- * sbat.c - parse SBAT data from the .rsrc section data
+ * sbat.c - parse SBAT data from the .sbat section data
  */
 
 #ifndef SBAT_H_

--- a/pe.c
+++ b/pe.c
@@ -1033,7 +1033,7 @@ handle_image (void *data, unsigned int datasize,
 			}
 		} else if (CompareMem(Section->Name, ".sbat\0\0\0", 8) == 0) {
 			if (SBATBase || SBATSize) {
-				perror(L"Image has multiple resource sections\n");
+				perror(L"Image has multiple SBAT sections\n");
 				return EFI_UNSUPPORTED;
 			}
 


### PR DESCRIPTION
Replace the resource section with SBAT section.