### PR TITLE
If the SBAT UEFI variable is not set, initialize it as a bootservicesvariable

### DIFF
--- a/include/sbat.h
+++ b/include/sbat.h
@@ -6,6 +6,16 @@
 #ifndef SBAT_H_
 #define SBAT_H_
 
+#define SBAT_VAR_SIG "sbat,"
+#define SBAT_VAR_VERSION "1,"
+#define SBAT_VAR_DATE "2021030218"
+#define SBAT_VAR SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_DATE "\n"
+
+#define UEFI_VAR_NV_BS \
+	(EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS)
+#define UEFI_VAR_NV_BS_TIMEAUTH \
+	(UEFI_VAR_NV_BS | EFI_VARIABLE_TIME_BASED_AUTHENTICATED_WRITE_ACCESS)
+
 extern UINTN _sbat, _esbat;
 
 struct sbat_var_entry {
@@ -23,6 +33,7 @@ extern list_t sbat_var;
 
 EFI_STATUS parse_sbat_var(list_t *entries);
 void cleanup_sbat_var(list_t *entries);
+EFI_STATUS set_sbat_uefi_variable(void);
 
 struct sbat_section_entry {
 	const CHAR8 *component_name;

--- a/shim.c
+++ b/shim.c
@@ -1759,7 +1759,8 @@ shim_init(void)
 void
 shim_fini(void)
 {
-	cleanup_sbat_var(&sbat_var);
+	if (secure_mode())
+		cleanup_sbat_var(&sbat_var);
 
 	/*
 	 * Remove our protocols
@@ -1865,6 +1866,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		L"shim_init() failed",
 		L"import of SBAT data failed",
 		L"SBAT self-check failed",
+		L"SBAT UEFI variable setting failed",
 		NULL
 	};
 	enum {
@@ -1872,6 +1874,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		SHIM_INIT,
 		IMPORT_SBAT,
 		SBAT_SELF_CHECK,
+		SET_SBAT,
 	} msg = IMPORT_MOK_STATE;
 
 	/*
@@ -1901,24 +1904,27 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	 */
 	debug_hook();
 
-	INIT_LIST_HEAD(&sbat_var);
-	efi_status = parse_sbat_var(&sbat_var);
-	/*
-	 * Until a SBAT variable is installed into the systems, it is expected that
-	 * attempting to parse the variable will fail with an EFI_NOT_FOUND error.
-	 *
-	 * Do not consider that error fatal for now.
-	 */
-	if (EFI_ERROR(efi_status) && efi_status != EFI_NOT_FOUND) {
-		perror(L"Parsing SBAT variable failed: %r\n",
-		       efi_status);
-		msg = IMPORT_SBAT;
-		goto die;
-	}
-
-	if (secure_mode ()) {
+	if (secure_mode()) {
 		char *sbat_start = (char *)&_sbat;
 		char *sbat_end = (char *)&_esbat;
+
+		INIT_LIST_HEAD(&sbat_var);
+		efi_status = parse_sbat_var(&sbat_var);
+		if (EFI_ERROR(efi_status)) {
+			efi_status = set_sbat_uefi_variable();
+			if (efi_status == EFI_INVALID_PARAMETER) {
+				perror(L"SBAT variable initialization failed\n");
+				msg = SET_SBAT;
+				goto die;
+			}
+			efi_status = parse_sbat_var(&sbat_var);
+			if (EFI_ERROR(efi_status)) {
+				perror(L"Parsing SBAT variable failed: %r\n",
+					efi_status);
+				msg = IMPORT_SBAT;
+				goto die;
+			}
+		}
 
 		efi_status = handle_sbat(sbat_start, sbat_end - sbat_start);
 		if (EFI_ERROR(efi_status)) {
@@ -1927,6 +1933,14 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 			msg = SBAT_SELF_CHECK;;
 			goto die;
 		}
+	}
+
+	efi_status = set_sbat_uefi_variable();
+	if (efi_status == EFI_INVALID_PARAMETER) {
+		perror(L"SBAT variable initialization failed\n");
+		msg = SET_SBAT;
+		if (secure_mode())
+                        goto die;
 	}
 
 	init_openssl();


### PR DESCRIPTION
I expect this will generate comments on where exactly to do the initialization.

This should probably use get_variable(), but there's no set_variable, and we need the flags.

Making sbat initialization non-fatal for non-secure mode may also be controversial.