### PR TITLE
Add get_variable_size() and set_variable() wrappers.

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -40,6 +40,12 @@ get_variable(const CHAR16 * const var, UINT8 **data, UINTN *len, EFI_GUID owner)
 EFI_STATUS
 get_variable_attr(const CHAR16 * const var, UINT8 **data, UINTN *len, EFI_GUID owner, UINT32 *attributes);
 EFI_STATUS
+get_variable_size(const CHAR16 * const var, EFI_GUID owner, UINTN *lenp);
+EFI_STATUS
+set_variable(CHAR16 *var, EFI_GUID owner, UINT32 attributes, UINTN datasize, void *data);
+EFI_STATUS
+del_variable(CHAR16 *var, EFI_GUID owner);
+EFI_STATUS
 find_in_esl(UINT8 *Data, UINTN DataSize, UINT8 *key, UINTN keylen);
 EFI_STATUS
 find_in_variable_esl(const CHAR16 * const var, EFI_GUID owner, UINT8 *key, UINTN keylen);

--- a/lib/variables.c
+++ b/lib/variables.c
@@ -260,6 +260,43 @@ get_variable(const CHAR16 * const var, UINT8 **data, UINTN *len, EFI_GUID owner)
 }
 
 EFI_STATUS
+get_variable_size(const CHAR16 * const var, EFI_GUID owner, UINTN *lenp)
+{
+	UINTN len = 0;
+	EFI_STATUS efi_status;
+
+	efi_status = get_variable_attr(var, NULL, &len, owner, NULL);
+	if (EFI_ERROR(efi_status)) {
+		if (efi_status == EFI_BUFFER_TOO_SMALL) {
+			*lenp = len;
+			return EFI_SUCCESS;
+		} else if (efi_status == EFI_NOT_FOUND) {
+			*lenp = 0;
+			return EFI_SUCCESS;
+		}
+		return efi_status;
+	}
+	/*
+	 * who knows what this means, but...
+	 */
+	*lenp = len;
+	return efi_status;
+}
+
+EFI_STATUS
+set_variable(CHAR16 *var, EFI_GUID owner, UINT32 attributes,
+	     UINTN datasize, void *data)
+{
+	return gRT->SetVariable(var, &owner, attributes, datasize, data);
+}
+
+EFI_STATUS
+del_variable(CHAR16 *var, EFI_GUID owner)
+{
+	return set_variable(var, owner, 0, 0, "");
+}
+
+EFI_STATUS
 find_in_esl(UINT8 *Data, UINTN DataSize, UINT8 *key, UINTN keylen)
 {
 	EFI_SIGNATURE_LIST *CertList;


### PR DESCRIPTION
This get_variable_size() implementation success in either of two cases:
- EFI_SUCCESS with *lenp == 0 if the variable isn't found
- EFI_SUCCESS with *lenp > 0 on success

In the event of other errors, it returns them to you.

There's nothing particularly interesting about the set_variable()
implementation here.

Signed-off-by: Peter Jones <pjones@redhat.com>