### PR TITLE
sbat: fix a few more gcc warnings

### DIFF
--- a/csv.c
+++ b/csv.c
@@ -21,8 +21,8 @@ parse_csv_line(char * line, size_t max, size_t *n_columns, const char *columns[]
 			valid = strntoken(next, max, delims, &token, &state);
 		}
 		if (valid) {
-			next += strlena(token) + 1;
-			max -= strlena(token) + 1;
+			next += strlena((CHAR8 *)token) + 1;
+			max -= strlena((CHAR8 *)token) + 1;
 			columns[n] = token;
 			new_n = n + 1;
 		} else {
@@ -60,7 +60,7 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 
 	max = (uintptr_t)end - (uintptr_t)line + (end > line ? 1 : 0);
 
-	if (line && is_utf8_bom(line, max))
+	if (line && is_utf8_bom((CHAR8 *)line, max))
 		line += UTF8_BOM_SIZE;
 
 	while (line && line <= data_end) {

--- a/sbat.c
+++ b/sbat.c
@@ -49,7 +49,7 @@ parse_sbat_section(char *section_base, size_t section_size,
 				efi_status = EFI_INVALID_PARAMETER;
 				goto err;
 			}
-			allocsz += strlena(row->columns[i]) + 1;
+			allocsz += strlena((CHAR8 *)row->columns[i]) + 1;
 		}
 		n++;
 	}
@@ -70,12 +70,12 @@ parse_sbat_section(char *section_base, size_t section_size,
 		struct csv_row * row;
 		size_t i;
 		const char **ptrs[] = {
-			&entry->component_name,
-			&entry->component_generation,
-			&entry->vendor_name,
-			&entry->vendor_package_name,
-			&entry->vendor_version,
-			&entry->vendor_url,
+			(const char **)&entry->component_name,
+			(const char **)&entry->component_generation,
+			(const char **)&entry->vendor_name,
+			(const char **)&entry->vendor_package_name,
+			(const char **)&entry->vendor_version,
+			(const char **)&entry->vendor_url,
 		};
 
 
@@ -227,7 +227,7 @@ parse_sbat_var_data(list_t *entry_list, UINT8 *data, UINTN datasize)
 				efi_status = EFI_INVALID_PARAMETER;
 				goto err;
 			}
-			allocsz += strlena(row->columns[i]) + 1;
+			allocsz += strlena((CHAR8 *)row->columns[i]) + 1;
 		}
 		n++;
 	}
@@ -250,9 +250,9 @@ parse_sbat_var_data(list_t *entry_list, UINT8 *data, UINTN datasize)
 		struct csv_row * row;
 		size_t i;
 		const char **ptrs[] = {
-			&entry->component_name,
-			&entry->component_generation,
-			&entry->sbat_datestamp,
+			(const char **)&entry->component_name,
+			(const char **)&entry->component_generation,
+			(const char **)&entry->sbat_datestamp,
 		};
 
 		row = list_entry(pos, struct csv_row, list);


### PR DESCRIPTION
Fix the following type-casting warnings.

sbat.c: In function 'parse_sbat_section':
sbat.c:52:23: error: pointer targets in passing argument 1 of 'strlena' differ in signedness [-Werror=pointer-sign]
    allocsz += strlena(row->columns[i]) + 1;
                       ^~~
In file included from shim.h:31:0,
                 from sbat.c:6:
/usr/include/efi/efilib.h:371:1: note: expected 'const CHAR8 * {aka const unsigned char *}' but argument is of type 'char *'
 strlena (
 ^~~~~~~
sbat.c:73:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->component_name,
    ^
sbat.c:73:4: note: (near initialization for 'ptrs[0]')
sbat.c:74:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->component_generation,
    ^
sbat.c:74:4: note: (near initialization for 'ptrs[1]')
sbat.c:75:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->vendor_name,
    ^
sbat.c:75:4: note: (near initialization for 'ptrs[2]')
sbat.c:76:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->vendor_package_name,
    ^
sbat.c:76:4: note: (near initialization for 'ptrs[3]')
sbat.c:77:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->vendor_version,
    ^
sbat.c:77:4: note: (near initialization for 'ptrs[4]')
sbat.c:78:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->vendor_url,
    ^
sbat.c:78:4: note: (near initialization for 'ptrs[5]')
sbat.c: In function 'parse_sbat_var_data':
sbat.c:230:23: error: pointer targets in passing argument 1 of 'strlena' differ in signedness [-Werror=pointer-sign]
    allocsz += strlena(row->columns[i]) + 1;
                       ^~~
In file included from shim.h:31:0,
                 from sbat.c:6:
/usr/include/efi/efilib.h:371:1: note: expected 'const CHAR8 * {aka const unsigned char *}' but argument is of type 'char *'
 strlena (
 ^~~~~~~
sbat.c:253:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->component_name,
    ^
sbat.c:253:4: note: (near initialization for 'ptrs[0]')
sbat.c:254:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->component_generation,
    ^
sbat.c:254:4: note: (near initialization for 'ptrs[1]')
sbat.c:255:4: error: initialization from incompatible pointer type [-Werror=incompatible-pointer-types]
    &entry->sbat_datestamp,
    ^
sbat.c:255:4: note: (near initialization for 'ptrs[2]')

csv.c: In function ‘parse_csv_line’:
csv.c:24:20: error: pointer targets in passing argument 1 of ‘strlena’
differ in signedness [-Werror=pointer-sign]
   24 |    next += strlena(token) + 1;
      |                    ^~~~~
      |                    |
      |                    char *
In file included from shim.h:31,
                 from csv.c:6:
/usr/include/efi/efilib.h:373:24: note: expected ‘const CHAR8 *’ {aka
‘const unsigned char *’} but argument is of type ‘char *’
  373 |     IN CONST CHAR8    *s1
csv.c:25:19: error: pointer targets in passing argument 1 of ‘strlena’
differ in signedness [-Werror=pointer-sign]
   25 |    max -= strlena(token) + 1;
      |                   ^~~~~
      |                   |
      |                   char *
In file included from shim.h:31,
                 from csv.c:6:
/usr/include/efi/efilib.h:373:24: note: expected ‘const CHAR8 *’ {aka
‘const unsigned char *’} but argument is of type ‘char *’
  373 |     IN CONST CHAR8    *s1
csv.c: In function ‘parse_csv_data’:
csv.c:63:26: error: pointer targets in passing argument 1 of
‘is_utf8_bom’ differ in signedness [-Werror=pointer-sign]
   63 |  if (line && is_utf8_bom(line, max))
      |                          ^~~~
      |                          |
      |                          char *
In file included from shim.h:157,
                 from csv.c:6:
include/str.h:221:20: note: expected ‘CHAR8 *’ {aka ‘unsigned char *’}
but argument is of type ‘char *’
  221 | is_utf8_bom(CHAR8 *buf, size_t bufsize)
      |             ~~~~~~~^~~

Signed-off-by: Gary Lin <glin@suse.com>