### PR TITLE
Restore loaded image of shim at Exit()

### DIFF
--- a/replacements.c
+++ b/replacements.c
@@ -133,6 +133,8 @@ do_exit(EFI_HANDLE ImageHandle, EFI_STATUS ExitStatus,
 
 	shim_fini();
 
+	restore_loaded_image();
+
 	efi_status = gBS->Exit(ImageHandle, ExitStatus,
 			       ExitDataSize, ExitData);
 	if (EFI_ERROR(efi_status)) {

--- a/shim.h
+++ b/shim.h
@@ -201,6 +201,7 @@ extern EFI_STATUS VLogError(const char *file, int line, const char *func, const 
 extern VOID LogHexdump_(const char *file, int line, const char *func, const void *data, size_t sz);
 extern VOID PrintErrors(VOID);
 extern VOID ClearErrors(VOID);
+extern VOID restore_loaded_image(VOID);
 extern EFI_STATUS start_image(EFI_HANDLE image_handle, CHAR16 *ImagePath);
 extern EFI_STATUS import_mok_state(EFI_HANDLE image_handle);
 


### PR DESCRIPTION
When grub2 invoked Exit() in AArch64 AAVMF, the VM crashed with the
following messsages:

Unloading driver at 0x000B7D7B000

Synchronous Exception at 0x00000000BF5D5E68
AllocatePool: failed to allocate 800 bytes

Synchronous Exception at 0x00000000BF5D5E68

The similar error also showed when I modified MokManager to call
gBS->Exit() at the end of efi_main(). However, if MokManager just
returned, the error never showed. One significant difference is
whether the loaded image was restored or not, and the firmware seems
to need the original ImageBase pointer to do clean-up.

To avoid the potential crash, this commit adds restore_loaded_image() so
that we can restore the loaded image both in start_image() and
do_exit().

Signed-off-by: Gary Lin <glin@suse.com>