### PR TITLE
Set the section flags for .sbat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,9 @@ VENDOR_SBATS := $(foreach x,$(wildcard data/sbat.*.csv),$(notdir $(x)))
 sbat_data.o : | $(SBATPATH) $(VENDOR_SBATS)
 sbat_data.o : /dev/null
 	$(CC) $(CFLAGS) -x c -c -o $@ $<
-	$(OBJCOPY) --add-section .sbat=$(SBATPATH) $@
+	$(OBJCOPY) --add-section .sbat=$(SBATPATH) \
+		--set-section-flags .sbat=contents,alloc,load,readonly,data \
+		$@
 	$(foreach vs,$(VENDOR_SBATS),$(call add-vendor-sbat,$(vs),$@))
 
 $(SHIMNAME) : $(SHIMSONAME)


### PR DESCRIPTION
When using "objcopy -O binary", it silently drops the sections without
"alloc" or "load" or the sections with "unload". Since we didn't set any
section flags for .sbat, it just contains the "readonly" flag and
objcopy ignored the section totally when generating EFI images for
ARM32 and AArch64.

This commit sets the common read-only data section flags to .sbat so
that objcopy would always copy the section to the final EFI image.

Signed-off-by: Gary Lin <glin@suse.com>