### PR TITLE
BUG: fix various build errors and warnings

### DIFF
--- a/Cryptlib/Library/BaseLib.h
+++ b/Cryptlib/Library/BaseLib.h
@@ -3,7 +3,7 @@
 
 UINT32 WriteUnaligned32 (UINT32 *Buffer, UINT32 Value);
 UINTN AsciiStrSize (CHAR8 *string);
-char *AsciiStrnCpy(char *Destination, char *Source, UINTN count);
+char *AsciiStrnCpy(char *Destination, const char *Source, UINTN count);
 char *AsciiStrCat(char *Destination, char *Source);
-CHAR8 *AsciiStrCpy(CHAR8 *Destination, CHAR8 *Source);
+char *AsciiStrCpy(char *Destination, const char *Source);
 UINTN AsciiStrDecimalToUintn(const char *String);

--- a/Cryptlib/OpenSSL/crypto/pkcs7/pk7_smime.c
+++ b/Cryptlib/OpenSSL/crypto/pkcs7/pk7_smime.c
@@ -530,7 +530,8 @@ PKCS7 *PKCS7_encrypt(STACK_OF(X509) *certs, BIO *in, const EVP_CIPHER *cipher,
 int PKCS7_decrypt(PKCS7 *p7, EVP_PKEY *pkey, X509 *cert, BIO *data, int flags)
 {
     BIO *tmpmem;
-    int ret, i;
+    int ret = 0; /* current openssl sets 'ret' to zero here */
+    int i;
     char *buf = NULL;
 
     if (!p7) {

--- a/Cryptlib/OpenSSL/crypto/rsa/rsa_ameth.c
+++ b/Cryptlib/OpenSSL/crypto/rsa/rsa_ameth.c
@@ -768,6 +768,7 @@ static int rsa_item_sign(EVP_MD_CTX *ctx, const ASN1_ITEM *it, void *asn,
     return 2;
 }
 
+#ifndef OPENSSL_NO_CMS
 static RSA_OAEP_PARAMS *rsa_oaep_decode(const X509_ALGOR *alg,
                                         X509_ALGOR **pmaskHash)
 {
@@ -791,7 +792,6 @@ static RSA_OAEP_PARAMS *rsa_oaep_decode(const X509_ALGOR *alg,
     return pss;
 }
 
-#ifndef OPENSSL_NO_CMS
 static int rsa_cms_decrypt(CMS_RecipientInfo *ri)
 {
     EVP_PKEY_CTX *pkctx;

--- a/Cryptlib/OpenSSL/crypto/x509/x509_vfy.c
+++ b/Cryptlib/OpenSSL/crypto/x509/x509_vfy.c
@@ -984,7 +984,8 @@ static int check_cert(X509_STORE_CTX *ctx)
 {
     X509_CRL *crl = NULL, *dcrl = NULL;
     X509 *x;
-    int ok, cnum;
+    int ok = 0; /* current openssl sets 'ok' to zero here */
+    int cnum;
     unsigned int last_reasons;
     cnum = ctx->error_depth;
     x = sk_X509_value(ctx->chain, cnum);

--- a/Cryptlib/SysCall/BaseStrings.c
+++ b/Cryptlib/SysCall/BaseStrings.c
@@ -13,8 +13,8 @@ AsciiStrCat(char *Destination, char *Source)
 	return Destination;
 }
 
-CHAR8 *
-AsciiStrCpy(CHAR8 *Destination, CHAR8 *Source)
+char *
+AsciiStrCpy(char *Destination, const char *Source)
 {
 	UINTN i;
 
@@ -26,7 +26,7 @@ AsciiStrCpy(CHAR8 *Destination, CHAR8 *Source)
 }
 
 char *
-AsciiStrnCpy(char *Destination, char *Source, UINTN count)
+AsciiStrnCpy(char *Destination, const char *Source, UINTN count)
 {
 	UINTN i;
 

--- a/csv.c
+++ b/csv.c
@@ -6,13 +6,13 @@
 #include "shim.h"
 
 void NONNULL(1, 3, 4)
-parse_csv_line(char * line, size_t max, size_t *n_columns, const char *columns[])
+parse_csv_line(CHAR8 * line, size_t max, size_t *n_columns, const CHAR8 *columns[])
 {
-	char *next = line;
+	CHAR8 *next = line;
 	size_t n = 0, new_n = n;
-	const char * const delims = ",";
-	char state = 0;
-	char *token = NULL;
+	const CHAR8 * const delims = (CHAR8 *)",";
+	CHAR8 state = 0;
+	CHAR8 *token = NULL;
 
 	bool valid = true;
 	for (n = 0; n < *n_columns; n++) {
@@ -47,13 +47,13 @@ free_csv_list(list_t *list)
 }
 
 EFI_STATUS
-parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
+parse_csv_data(CHAR8 *data, CHAR8 *data_end, size_t n_columns, list_t *list)
 {
 	EFI_STATUS efi_status = EFI_OUT_OF_RESOURCES;
-	char delims[] = "\r\n";
-	char *line = data;
+	CHAR8 delims[] = "\r\n";
+	CHAR8 *line = data;
 	size_t max = 0;
-	char *end = data_end;
+	CHAR8 *end = data_end;
 
 	if (!data || !end || end <= data || !n_columns || !list)
 		return EFI_INVALID_PARAMETER;
@@ -64,10 +64,10 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 		line += UTF8_BOM_SIZE;
 
 	while (line && line <= data_end) {
-		size_t entrysz = sizeof(char *) * n_columns + sizeof(struct csv_row);
+		size_t entrysz = sizeof(CHAR8 *) * n_columns + sizeof(struct csv_row);
 		struct csv_row *entry;
 		size_t m_columns = n_columns;
-		char *delim;
+		CHAR8 *delim;
 		bool found = true;
 
 		end = data_end;
@@ -83,7 +83,7 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 			}
 		}
 		for (delim = &delims[0]; *delim; delim++) {
-			char *tmp = strnchrnul(line, max, *delim);
+			CHAR8 *tmp = strnchrnul(line, max, *delim);
 			if (tmp < end)
 				end = tmp;
 		}
@@ -105,12 +105,12 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 		list_add_tail(&entry->list, list);
 
 		for (delim = &delims[0]; *delim; delim++) {
-			char *tmp = strnchrnul((const char *)line, max, *delim);
+			CHAR8 *tmp = strnchrnul(line, max, *delim);
 			if (tmp < end)
 				end = tmp;
 		}
 
-		parse_csv_line(line, max, &m_columns, (const char **)entry->columns);
+		parse_csv_line(line, max, &m_columns, (const CHAR8 **)entry->columns);
 		entry->n_columns = m_columns;
 		line = end + 1;
 	}

--- a/httpboot.c
+++ b/httpboot.c
@@ -727,7 +727,7 @@ httpboot_fetch_buffer (EFI_HANDLE image, VOID **buffer, UINT64 *buf_size)
 	if (!uri)
 		return EFI_NOT_READY;
 
-	translate_slashes(next_loader, DEFAULT_LOADER_CHAR);
+	translate_slashes(next_loader, (CHAR8 *)DEFAULT_LOADER_CHAR);
 
 	/* Create the URI for the next loader based on the original URI */
 	efi_status = generate_next_uri(uri, next_loader, &next_uri);

--- a/include/pe.h
+++ b/include/pe.h
@@ -15,7 +15,7 @@ read_header(void *data, unsigned int datasize,
 	    PE_COFF_LOADER_IMAGE_CONTEXT *context);
 
 EFI_STATUS
-handle_sbat(char *SBATBase, size_t SBATSize);
+handle_sbat(CHAR8 *SBATBase, size_t SBATSize);
 
 EFI_STATUS
 handle_image (void *data, unsigned int datasize,
@@ -25,7 +25,7 @@ handle_image (void *data, unsigned int datasize,
 	      UINTN *alloc_pages);
 
 EFI_STATUS
-generate_hash (char *data, unsigned int datasize_in,
+generate_hash (CHAR8 *data, unsigned int datasize_in,
 	       PE_COFF_LOADER_IMAGE_CONTEXT *context,
 	       UINT8 *sha256hash, UINT8 *sha1hash);
 

--- a/include/sbat.h
+++ b/include/sbat.h
@@ -35,7 +35,7 @@ struct sbat_section_entry {
 #define SBAT_SECTION_COLUMNS (sizeof (struct sbat_section_entry) / sizeof(CHAR8 *))
 
 EFI_STATUS
-parse_sbat_section(char *section_base, size_t section_size, size_t *n,
+parse_sbat_section(CHAR8 *section_base, size_t section_size, size_t *n,
 		   struct sbat_section_entry ***entriesp);
 void cleanup_sbat_section_entries(size_t n, struct sbat_section_entry **entries);
 

--- a/include/str.h
+++ b/include/str.h
@@ -71,8 +71,8 @@ strndupa(const CHAR8 * const src, const UINTN srcmax)
 	return news;
 }
 
-static inline UNUSED RETURNS_NONNULL NONNULL(1, 2) char *
-stpcpy(char *dest, const char * const src)
+static inline UNUSED RETURNS_NONNULL NONNULL(1, 2) CHAR8 *
+stpcpy(CHAR8 *dest, const CHAR8 * const src)
 {
 	size_t i = 0;
 	for (i = 0; src[i]; i++)
@@ -81,8 +81,24 @@ stpcpy(char *dest, const char * const src)
 	return &dest[i];
 }
 
+
+static inline UNUSED RETURNS_NONNULL NONNULL(1) CHAR8 *
+strrchra(CHAR8 *str, int c)
+{
+	CHAR8 * save;
+
+	for (save = NULL; ; ++str) {
+		if (*str == c) {
+			save = str;
+		}
+		if (*str == 0) {
+			return save;
+		}
+	}
+}
+
 static inline UNUSED CHAR8 *
-translate_slashes(CHAR8 *out, const char *str)
+translate_slashes(CHAR8 *out, const CHAR8 *str)
 {
 	int i;
 	int j;
@@ -124,13 +140,13 @@ strchra(const CHAR8 *s, int c)
 	return (CHAR8 *)s1;
 }
 
-static inline UNUSED RETURNS_NONNULL NONNULL(1) char *
-strnchrnul(const char *s, size_t max, int c)
+static inline UNUSED RETURNS_NONNULL NONNULL(1) CHAR8 *
+strnchrnul(CHAR8 *s, size_t max, int c)
 {
 	unsigned int i;
 
 	if (!s || !max)
-		return (char *)s;
+		return s;
 
 	for (i = 0; i < max && s[i] != '\0' && s[i] != c; i++)
 		;
@@ -138,7 +154,7 @@ strnchrnul(const char *s, size_t max, int c)
 	if (i == max)
 		i--;
 
-	return (char *)&s[i];
+	return &s[i];
 }
 
 /**
@@ -150,14 +166,14 @@ strnchrnul(const char *s, size_t max, int c)
  * state: a pointer to one char of state for between calls
  *
  * Ensure that both token and state are preserved across calls.  Do:
- *   char state = 0;
- *   char *token = NULL;
+ *   CHAR8 state = 0;
+ *   CHAR8 *token = NULL;
  *   for (...) {
  *     valid = strntoken(...)
  * not:
- *   char state = 0;
+ *   CHAR8 state = 0;
  *   for (...) {
- *     char *token = NULL;
+ *     CHAR8 *token = NULL;
  *     valid = strntoken(...)
  *
  * - it will not test bytes beyond str[max-1]
@@ -173,10 +189,10 @@ strnchrnul(const char *s, size_t max, int c)
  * false means it got to a NUL or str[max-1] and token is invalid
  */
 static inline UNUSED NONNULL(1, 3, 4) int
-strntoken(char *str, size_t max, const char *delims, char **token, char *state)
+strntoken(CHAR8 *str, size_t max, const CHAR8 *delims, CHAR8 **token, CHAR8 *state)
 {
-	char *tokend;
-	const char *delim;
+	CHAR8 *tokend;
+	const CHAR8 *delim;
 	int isdelim = 0;
 	int state_is_delim = 0;
 
@@ -196,7 +212,7 @@ strntoken(char *str, size_t max, const char *delims, char **token, char *state)
 	}
 
 	for (delim = delims; *delim; delim++) {
-		char *tmp = NULL;
+		CHAR8 *tmp = NULL;
 		if (*token && *delim == *state)
 			state_is_delim = 1;
 		tmp = strnchrnul(str, max, *delim);
@@ -220,7 +236,7 @@ strntoken(char *str, size_t max, const char *delims, char **token, char *state)
 static inline UNUSED NONNULL(1) BOOLEAN
 is_utf8_bom(CHAR8 *buf, size_t bufsize)
 {
-	unsigned char bom[] = UTF8_BOM;
+	CHAR8 bom[] = UTF8_BOM;
 
 	return CompareMem(buf, bom, MIN(UTF8_BOM_SIZE, bufsize)) == 0;
 }
@@ -249,16 +265,16 @@ is_utf8_bom(CHAR8 *buf, size_t bufsize)
 struct csv_row {
 	list_t list;		/* this is a linked list */
 	size_t n_columns;	/* this is how many columns are actually populated */
-	char *columns[0];	/* these are pointers to columns */
+	CHAR8 *columns[0];	/* these are pointers to columns */
 };
 
-EFI_STATUS parse_csv_data(char *data, char *end, size_t n_columns,
+EFI_STATUS parse_csv_data(CHAR8 *data, CHAR8 *end, size_t n_columns,
                           list_t *list);
 void free_csv_list(list_t *list);
 
 #ifdef SHIM_UNIT_TEST
 void NONNULL(1, 3, 4)
-parse_csv_line(char * line, size_t max, size_t *n_columns, const char *columns[]);
+parse_csv_line(CHAR8 * line, size_t max, size_t *n_columns, const CHAR8 *columns[]);
 #endif
 
 #endif /* SHIM_STR_H */

--- a/netboot.c
+++ b/netboot.c
@@ -169,7 +169,7 @@ static BOOLEAN extract_tftp_info(CHAR8 *url)
 	CHAR8 ip6inv[16];
 	CHAR8 template[sizeof DEFAULT_LOADER_CHAR];
 
-	translate_slashes(template, DEFAULT_LOADER_CHAR);
+	translate_slashes(template, (CHAR8 *)DEFAULT_LOADER_CHAR);
 
 	// to check against str2ip6() errors
 	memset(ip6inv, 0, sizeof(ip6inv));
@@ -207,9 +207,9 @@ static BOOLEAN extract_tftp_info(CHAR8 *url)
 	if (!full_path)
 		return FALSE;
 	memcpy(full_path, end, strlen(end));
-	end = (CHAR8 *)strrchr((char *)full_path, '/');
+	end = strrchra(full_path, '/');
 	if (!end)
-		end = (CHAR8 *)full_path;
+		end = full_path;
 	memcpy(end, template, strlen(template));
 	end[strlen(template)] = '\0';
 
@@ -239,7 +239,7 @@ static EFI_STATUS parseDhcp4()
 	UINTN template_ofs = 0;
 	EFI_PXE_BASE_CODE_DHCPV4_PACKET* pkt_v4 = (EFI_PXE_BASE_CODE_DHCPV4_PACKET *)&pxe->Mode->DhcpAck.Dhcpv4;
 
-	translate_slashes(template, DEFAULT_LOADER_CHAR);
+	translate_slashes(template, (CHAR8 *)DEFAULT_LOADER_CHAR);
 	template_len = strlen(template) + 1;
 
 	if(pxe->Mode->ProxyOfferReceived) {

--- a/sbat.c
+++ b/sbat.c
@@ -7,17 +7,17 @@
 #include "string.h"
 
 EFI_STATUS
-parse_sbat_section(char *section_base, size_t section_size,
+parse_sbat_section(CHAR8 *section_base, size_t section_size,
 		   size_t *n_entries,
 		   struct sbat_section_entry ***entriesp)
 {
 	struct sbat_section_entry *entry = NULL, **entries;
 	EFI_STATUS efi_status = EFI_SUCCESS;
 	list_t csv, *pos = NULL;
-	char * end = section_base + section_size - 1;
+	CHAR8 * end = section_base + section_size - 1;
 	size_t allocsz = 0;
 	size_t n;
-	char *strtab;
+	CHAR8 *strtab;
 
 	if (!section_base || !section_size || !n_entries || !entriesp)
 		return EFI_INVALID_PARAMETER;
@@ -69,7 +69,7 @@ parse_sbat_section(char *section_base, size_t section_size,
 	list_for_each(pos, &csv) {
 		struct csv_row * row;
 		size_t i;
-		const char **ptrs[] = {
+		const CHAR8 **ptrs[] = {
 			&entry->component_name,
 			&entry->component_generation,
 			&entry->vendor_name,
@@ -109,7 +109,7 @@ verify_single_entry(struct sbat_section_entry *entry, struct sbat_var_entry *sba
 {
 	UINT16 sbat_gen, sbat_var_gen;
 
-	if (strcmp((const char *)entry->component_name, (const char *)sbat_var_entry->component_name) == 0) {
+	if (strcmpa(entry->component_name, sbat_var_entry->component_name) == 0) {
 		dprint(L"component %a has a matching SBAT variable entry, verifying\n",
 			entry->component_name);
 
@@ -191,11 +191,11 @@ parse_sbat_var_data(list_t *entry_list, UINT8 *data, UINTN datasize)
 	struct sbat_var_entry *entry = NULL, **entries;
 	EFI_STATUS efi_status = EFI_SUCCESS;
 	list_t csv, *pos = NULL;
-	char * start = (char *)data;
-	char * end = (char *)data + datasize - 1;
+	CHAR8 * start = (CHAR8 *)data;
+	CHAR8 * end = (CHAR8 *)data + datasize - 1;
 	size_t allocsz = 0;
 	size_t n;
-	char *strtab;
+	CHAR8 *strtab;
 
 	if (!entry_list|| !data || datasize == 0)
 		return EFI_INVALID_PARAMETER;
@@ -249,7 +249,7 @@ parse_sbat_var_data(list_t *entry_list, UINT8 *data, UINTN datasize)
 	list_for_each(pos, &csv) {
 		struct csv_row * row;
 		size_t i;
-		const char **ptrs[] = {
+		const CHAR8 **ptrs[] = {
 			&entry->component_name,
 			&entry->component_generation,
 			&entry->sbat_datestamp,

--- a/shim.c
+++ b/shim.c
@@ -586,6 +586,7 @@ verify_buffer (char *data, int datasize,
 	size_t size = datasize;
 	size_t offset = 0;
 	unsigned int i = 0;
+	CHAR8 *datap = (CHAR8 *)data;
 
 	if (datasize < 0)
 		return EFI_INVALID_PARAMETER;
@@ -597,7 +598,7 @@ verify_buffer (char *data, int datasize,
 	 */
 	drain_openssl_errors();
 
-	ret_efi_status = generate_hash(data, datasize, context, sha256hash, sha1hash);
+	ret_efi_status = generate_hash(datap, datasize, context, sha256hash, sha1hash);
 	if (EFI_ERROR(ret_efi_status)) {
 		dprint(L"generate_hash: %r\n", ret_efi_status);
 		PrintErrors();
@@ -656,7 +657,7 @@ verify_buffer (char *data, int datasize,
 		WIN_CERTIFICATE_EFI_PKCS *sig = NULL;
 		size_t sz;
 
-		sig = ImageAddress(data, size,
+		sig = ImageAddress(datap, size,
 				   context->SecDir->VirtualAddress + offset);
 		if (!sig)
 			break;
@@ -1052,7 +1053,7 @@ static EFI_STATUS shim_hash (char *data, int datasize,
 		return EFI_INVALID_PARAMETER;
 
 	in_protocol = 1;
-	efi_status = generate_hash(data, datasize, context,
+	efi_status = generate_hash((CHAR8 *)data, datasize, context,
 				   sha256hash, sha1hash);
 	in_protocol = 0;
 
@@ -1918,8 +1919,8 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	}
 
 	if (secure_mode ()) {
-		char *sbat_start = (char *)&_sbat;
-		char *sbat_end = (char *)&_esbat;
+		CHAR8 *sbat_start = (CHAR8 *)&_sbat;
+		CHAR8 *sbat_end = (CHAR8 *)&_esbat;
 
 		efi_status = handle_sbat(sbat_start, sbat_end - sbat_start);
 		if (EFI_ERROR(efi_status)) {


### PR DESCRIPTION
Most of the fatal build errors were due to the sign difference between 'char' and 'CHAR8' (CHAR8 is a 'unsigned char'), but there were a few other minor errors as well.

There were a couple cases of "uninitialized variable" warnings in the imported OpenSSL code; I used the current OpenSSL code as a guide for picking the default values used here.

On my dev system there is one remaining build warning in OpenSSL's crypto/asn1/x_pkey.c:X509_PKEY_new() function.  Unfortunately it involves some preprocessor crimes and the fix would be a bit ugly. Fortunately it appears the warning here is harmless and can be ignored.

As a point of reference, my build system is a current Arch install with GCC v10.2.0 and GNU-EFI v 3.0.12.

Signed-off-by: Paul Moore <pmoore2@cisco.com>