### PR TITLE
Make .sbat work on arm platforms

### DIFF
--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -58,14 +58,6 @@ SECTIONS
     *(.vendor_cert)
   }
   . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-    _esbat = .;
-  }
-  . = ALIGN(4096);
   .rela :
   {
     *(.rela.dyn)
@@ -76,6 +68,15 @@ SECTIONS
   }
   _edata = .;
   _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -56,14 +56,6 @@ SECTIONS
     *(.vendor_cert)
   }
   . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-    _esbat = .;
-  }
-  . = ALIGN(4096);
   .rel :
   {
     *(.rel.dyn)
@@ -74,6 +66,15 @@ SECTIONS
   }
   _edata = .;
   _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }

--- a/elf_ia32_efi.lds
+++ b/elf_ia32_efi.lds
@@ -54,14 +54,6 @@ SECTIONS
    *(.vendor_cert)
   }
   . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-    _esbat = .;
-  }
-  . = ALIGN(4096);
   .dynamic  : { *(.dynamic) }
   . = ALIGN(4096);
   .rel :
@@ -77,6 +69,16 @@ SECTIONS
   }
   _edata = .;
   _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
+
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }
   . = ALIGN(4096);

--- a/elf_ia64_efi.lds
+++ b/elf_ia64_efi.lds
@@ -56,14 +56,6 @@ SECTIONS
    *(.vendor_cert)
   }
   . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-    _esbat = .;
-  }
-  . = ALIGN(4096);
   .dynamic  : { *(.dynamic) }
   . = ALIGN(4096);
   .rela :
@@ -78,6 +70,16 @@ SECTIONS
   }
   _edata = .;
   _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
+
   . = ALIGN(4096);
   .reloc :		/* This is the PECOFF .reloc section! */
   {

--- a/elf_x86_64_efi.lds
+++ b/elf_x86_64_efi.lds
@@ -61,14 +61,6 @@ SECTIONS
    *(.vendor_cert)
   }
   . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-    _esbat = .;
-  }
-  . = ALIGN(4096);
   .dynamic  : { *(.dynamic) }
   . = ALIGN(4096);
   .rela :
@@ -79,6 +71,15 @@ SECTIONS
   }
   _edata = .;
   _data_size = . - _data;
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+  }
+  _esbat = .;
+  _sbat_size = . - _sbat;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }


### PR DESCRIPTION
This adds .sbat to the section headers on our arm and aarch64 binaries.

With this change, I see this on an fbaa64.efi binary (moderately hex-edited so objdump works):
```
Sections:
Idx Name          Size      VMA               LMA               File off  Algn
  0 .text         0000e000  0000000000001000  0000000000001000  00001000  2**4
                  CONTENTS, ALLOC, LOAD, READONLY, CODE
  1 .data         00003488  000000000000f000  000000000000f000  0000f000  2**4
                  CONTENTS, ALLOC, LOAD, DATA
  2 .sbat         00000083  0000000000013000  0000000000013000  00013000  2**3
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
Contents of section .sbat:
 13000 73626174 2c312c53 42415420 56657273  sbat,1,SBAT Vers
 13010 696f6e2c 73626174 2c312c68 74747073  ion,sbat,1,https
 13020 3a2f2f67 69746875 622e636f 6d2f7268  ://github.com/rh
 13030 626f6f74 2f736869 6d2f626c 6f622f6d  boot/shim/blob/m
 13040 61696e2f 53424154 2e6d640a 7368696d  ain/SBAT.md.shim
 13050 2c312c55 45464920 7368696d 2c736869  ,1,UEFI shim,shi
 13060 6d2c312c 68747470 733a2f2f 67697468  m,1,https://gith
 13070 75622e63 6f6d2f72 68626f6f 742f7368  ub.com/rhboot/sh
 13080 696d0a                               im.             
```



Resolves: https://github.com/rhboot/shim/issues/297