### PR TITLE
shim: Fix a NULL pointer dereference caused by start not being set

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1520,7 +1520,7 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 	 * case.
 	 */
 	if (strings == 1) {
-		UINT16 *cur = li->LoadOptions;
+		UINT16 *cur = start = li->LoadOptions;
 
 		/* replace L' ' with L'\0' if we find any */
 		for (i = 0; i < li->LoadOptionsSize / 2; i++) {


### PR DESCRIPTION
Commit 018b74d2d69 ("shim: attempt to improve the argument handling") added
added workarounds for a couple of LoadOption problems on some systems, but
introduced a regression since the is_our_path() function can be called with
a NULL start UCS-2 string.

If there's only one string, set start to the start of LoadOptions.

Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>