### PR TITLE
Nerf an unnecessary string test on arm.

### DIFF
--- a/test-str.c
+++ b/test-str.c
@@ -478,6 +478,11 @@ gnuefi_strncmp (
     return len ? *s1 - *s2 : 0;
 }
 
+/*
+ * This is still broken, and fails the test case as written on arm.
+ * We no longer use this, so we do not strictly need to run it.
+ */
+#if !defined(__arm__) && !defined(__aarch64__)
 static inline INTN
 gnuefi_signed_strncmp (
     IN CONST CHAR8    *s1,
@@ -497,6 +502,7 @@ gnuefi_signed_strncmp (
 
     return len ? *s1 - *s2 : 0;
 }
+#endif
 
 static inline INTN
 gnuefi_good_strncmp (
@@ -708,10 +714,16 @@ test_strncmp(void)
 #pragma GCC diagnostic pop
 
 	/*
+	 * This is still broken, and fails the test case as written on arm.
+	 * We no longer use this, so we do not strictly need to run it.
+	 */
+#if !defined(__arm__) && !defined(__aarch64__)
+	/*
 	 * gnu-efi's broken strncmpa with the return type fixed
 	 */
 	rc = test_strncmp_helper(gnuefi_signed_strncmp, true, false, true);
 	status = MIN(rc, status);
+#endif
 
 	/*
 	 * gnu-efi's strncmpa with the return type fixed and unsigned


### PR DESCRIPTION
Steve McIntyre reports:

<Sledge> yay, arm64 string test fail
<Sledge> testing gnuefi_signed_strncmp
<Sledge> test_strncmp:713:got 128, expected < 0
<Sledge> test_strncmp:713:Assertion `(gnuefi_signed_strncmp("sbat\314\234\014,", "sbat\314\034\014,", 9)) >= 0' failed.
<Sledge> gnuefi_signed_strncmp failed
<Sledge> looking at that code, this is a test to check how broken the gnuefi strncmp is, yes?
<Sledge> and we're not actually using this implementation in shim AFAICS?

That is a correct understanding, and as such this patch just removes
that test from running on Arm platforms, where it is still too broken to
even do this much.

Signed-off-by: Peter Jones <pjones@redhat.com>