### PR TITLE
Disable a specific strncmp test on arm64

### DIFF
--- a/test-str.c
+++ b/test-str.c
@@ -707,11 +707,13 @@ test_strncmp(void)
 	status = MIN(rc, status);
 #pragma GCC diagnostic pop
 
+#ifndef __aarch64__
 	/*
 	 * gnu-efi's broken strncmpa with the return type fixed
 	 */
 	rc = test_strncmp_helper(gnuefi_signed_strncmp, true, false, true);
 	status = MIN(rc, status);
+#endif
 
 	/*
 	 * gnu-efi's strncmpa with the return type fixed and unsigned


### PR DESCRIPTION
This test demonstrates that gnuefi_signed_strncmp() is broken on
arm64. We knew that, don't break when we're doing a build. We don't
use this implementation anyway...

Signed-off-by: Steve McIntyre <93sam@debian.org>