### PR TITLE
Fix up build of test code using gcc 8

### DIFF
--- a/include/system/stdarg.h
+++ b/include/system/stdarg.h
@@ -24,7 +24,7 @@ typedef __builtin_va_list __builtin_sysv_va_list;
 #endif
 
 #if defined(__aarch64__) || defined(__arm__) || defined(__i386__) || \
-	defined(__i486__) || defined(__i686__) || defined(SHIM_UNIT_TEST)
+	defined(__i486__) || defined(__i686__)
 
 typedef __builtin_va_list ms_va_list;
 typedef __builtin_va_list __builtin_ms_va_list;


### PR DESCRIPTION
Don't check SHIM_UNIT_TEST.

This fixes conflicting declarations for __builtin_ms_va_list on amd64:

In file included from shim.h:47,
                 from test.c:10:
../include/system/stdarg.h:30:27: error: conflicting types for '__builtin_ms_va_list'
 typedef __builtin_va_list __builtin_ms_va_list;
                           ^~~~~~~~~~~~~~~~~~~~
cc1: note: previous declaration of '__builtin_ms_va_list' was here
In file included from shim.h:47,
                 from test-csv.c:9:
../include/system/stdarg.h:30:27: error: conflicting types for '__builtin_ms_va_list'
 typedef __builtin_va_list __builtin_ms_va_list;
                           ^~~~~~~~~~~~~~~~~~~~
cc1: note: previous declaration of '__builtin_ms_va_list' was here
In file included from shim.h:47,
                 from csv.c:6:
../include/system/stdarg.h:30:27: error: conflicting types for '__builtin_ms_va_list'
 typedef __builtin_va_list __builtin_ms_va_list;
                           ^~~~~~~~~~~~~~~~~~~~
cc1: note: previous declaration of '__builtin_ms_va_list' was here

Signed-off-by: Steve McIntyre <93sam@debian.org>