### PR TITLE
arm and aarch64: fix some PE headers.

### DIFF
--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -77,6 +77,7 @@ SECTIONS
   }
   _esbat = .;
   _sbat_size = . - _sbat;
+  _alldata_size = . - _data;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -75,6 +75,7 @@ SECTIONS
   }
   _esbat = .;
   _sbat_size = . - _sbat;
+  _alldata_size = . - _data;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }


### PR DESCRIPTION
This fixes the SizeOfImage and SizeOfInitializedData headers on arm and
aa64.

Signed-off-by: Peter Jones <pjones@redhat.com>