### PR TITLE
RFE: cherry pick Make.local from shim-15.2 to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Make.local
 *.a
 *.CSV
 *.cer

--- a/Make.defaults
+++ b/Make.defaults
@@ -1,3 +1,7 @@
+
+# load the local configuration if it exists
+-include Make.local
+
 COMPILER	?= gcc
 CC		= $(CROSS_COMPILE)$(COMPILER)
 LD		= $(CROSS_COMPILE)ld


### PR DESCRIPTION
If the file Make.local exists, use it as a source of local build
configuration by including it in Make.defaults.

(cherry picked from commit 57e38a1ebf73 in the shim-15.2 branch)

Signed-off-by: Paul Moore <pmoore2@cisco.com>