### PR TITLE
arm and aarch64: include the aligned part in SizeOfRawData of sbat

### DIFF
--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -76,6 +76,8 @@ SECTIONS
     *(.sbat.*)
   }
   _esbat = .;
+  _sbat_vsize = . - _sbat;
+  . = ALIGN(4096);
   _sbat_size = . - _sbat;
   _alldata_size = . - _data;
 

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -74,6 +74,8 @@ SECTIONS
     *(.sbat.*)
   }
   _esbat = .;
+  _sbat_vsize = . - _sbat;
+  . = ALIGN(4096);
   _sbat_size = . - _sbat;
   _alldata_size = . - _data;
 


### PR DESCRIPTION
Similar to x86_64, the .sbat section is aligned to 4096, so we should
include the aligned part in SizeOfRawData as objcopy does for x86_64.
For VirtualSize, _sbat_vsize is used to reflect the actually size of
sbat.

This also fixes a strange hash mismatching in openSUSE build service
when attaching signature to AArch64 EFI images from shim package.

Signed-off-by: Gary Lin <glin@suse.com>