### PR TITLE
shim: Use the default loader if an EFI_LOAD_OPTION can't be parsed

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1545,11 +1545,8 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 							   li->LoadOptionsSize,
 							   (UINT8 **)&start,
 							   &loader_len);
-		if (EFI_ERROR(efi_status)) {
-			/* maybe this is just a single string? */
-			start = li->LoadOptions;
-			loader_len = li->LoadOptionsSize;
-		}
+		if (EFI_ERROR(efi_status))
+			return EFI_SUCCESS;
 
 		remaining_size = 0;
 	} else if (strings >= 2) {


### PR DESCRIPTION
If the LoadOptions string count is zero, then it's assumed that it is an
EFI_LOAD_OPTION and the OptionalData field attempt to be parsed. If that
fails as well, in the second stage was set to the default loader path.

But this behaviour was changed by the commit 018b74d2 ("shim: attempt to
improve the argument handling"), and not in that case the LoadOptions is
attempted to be used as a single string. This breaks some firmwares that
return something in the LoadOptions but are not a proper EFI device path.

Instead of making assumptions about the LoadOptions if can't be parsed
correctly, just use the default loader as it was done before that commit.

Reported-by: Thomas Frauendorfer | Miray Software <tf@miray.de>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>