### PR TITLE
Sort input file names in lib/Makefile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,6 +1,7 @@
 TARGET = lib.a
 
-LIBFILES = $(foreach x,$(wildcard *.c),$(patsubst %.c,%.o,$(x)))
+LIBFILES_UNSORTED := $(foreach x,$(wildcard *.c),$(patsubst %.c,%.o,$(x)))
+LIBFILES := $(sort $(LIBFILES_UNSORTED))
 
 CRYPTDIR	= $(TOPDIR)/Cryptlib
 


### PR DESCRIPTION
The order in which the foreach() returns files differes from
Debian on WSL1 and Debian running natively.
When shim is build on these two platforms the resulting binaries differ.

This patch manually sorts the input file list to create identical binaries.

Signed-off-by: Thomas Frauendorfer | Miray Software <tf@miray.de>