### PR TITLE
Ensure that MOK variable mirroring creates well formed ESLs

### DIFF
--- a/include/variables.h
+++ b/include/variables.h
@@ -64,12 +64,20 @@ EFI_STATUS
 variable_enroll_hash(const CHAR16 * const var, EFI_GUID owner,
 		     UINT8 hash[SHA256_DIGEST_SIZE]);
 EFI_STATUS
-variable_create_esl(const uint8_t *cert, const size_t cert_len,
-		    const EFI_GUID *type, const EFI_GUID *owner,
+variable_create_esl(const EFI_SIGNATURE_DATA *first_sig, const size_t howmany,
+		    const EFI_GUID *type, const UINT32 sig_size,
 		    uint8_t **out, size_t *outlen);
 EFI_STATUS
-fill_esl(const uint8_t *data, const size_t data_len,
-	 const EFI_GUID *type, const EFI_GUID *owner,
+variable_create_esl_with_one_signature(const uint8_t* data, const size_t data_len,
+				       const EFI_GUID *type, const EFI_GUID *owner,
+				       uint8_t **out, size_t *outlen);
+EFI_STATUS
+fill_esl(const EFI_SIGNATURE_DATA *first_sig, const size_t howmany,
+	 const EFI_GUID *type, const UINT32 sig_size,
 	 uint8_t *out, size_t *outlen);
+EFI_STATUS
+fill_esl_with_one_signature(const uint8_t *data, const uint32_t data_len,
+			    const EFI_GUID *type, const EFI_GUID *owner,
+			    uint8_t *out, size_t *outlen);
 
 #endif /* SHIM_VARIABLES_H */


### PR DESCRIPTION
The MOK variable mirroring makes use of variable_create_esl, which
can only create a well-formed EFI_SIGNATURE_LIST containing a single
signature. Fix fill_esl and variable_create_esl to support creating
a EFI_SIGNATURE_LIST with one or more supplied EFI_SIGNATURE_DATA
structures.

Introduce variable_create_esl_with_one_signature and
fill_esl_with_one_signature for code that does want to create a
EFI_SIGNATURE_LIST containing a single signature constructed from
a supplied signature data buffer and owner GUID.