### PR TITLE
Fix boot failures due to variable size constraints

### DIFF
--- a/lib/variables.c
+++ b/lib/variables.c
@@ -22,7 +22,7 @@ fill_esl(const EFI_SIGNATURE_DATA *first_sig, const size_t howmany,
 	size_t needed = 0;
 	size_t data_len = howmany * sig_size;
 
-	dprint(L"fill_esl: data=%p, data_len=%lu", first_sig, data_len);
+	dprint(L"fill_esl: first_sig=0x%llx, data_len=%lu\n", first_sig, data_len);
 
 	if ((out && !first_sig) || !howmany || !type || !sig_size || !outlen)
 		return EFI_INVALID_PARAMETER;


### PR DESCRIPTION
There are multiple issues in the MOK variable mirroring code due
to volatile variable size constraints, which all result in boot
failures:

- If a signature is encountered which doesn't fit in to a single
variable, the code enters an infinite loop because the cursor
isn't advanced in mirror_mok_db() after the call to
mirror_one_esl().

- If an ESL is encountered which doesn't fit in to a single
variable, it looks like the intention is for the ESL to be split
across multiple variables. However, mirror_one_esl() will write
the maximum variable size on each call, regardless of how much
data is remaining for the current ESL. If the size of a ESL isn't
a multiple of the maximum variable size, the final call to
mirror_one_esl() will append data from the start of the next
ESL and the cursor in mirror_mok_db() will be advanced to an
arbitrary location in the next ESL. This either results in garbage
being mirrored (if you're lucky), or in my case - another infinite
loop as it appears to encounter a signature that doesn't fit in to
a single variable.

- If no signatures can be mirrored when mirror_mok_db() is called
with only_first=TRUE, it tries to create a variable with a single
SHA256 signature in it. But mirror_mok_db() returns an error
(EFI_INVALID_PARAMETER) regardless of whether this succeeds.