### PR TITLE
Compute correct PE hashes for unsigned binaries

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -517,13 +517,16 @@ generate_hash(char *data, unsigned int datasize_in,
 		SumOfBytesHashed += Section->SizeOfRawData;
 	}
 
-	/* Hash all remaining data up to SecDir if SecDir->Size is not 0 */
-	if (datasize > SumOfBytesHashed && context->SecDir->Size) {
+	/*
+	 * Hash all remaining bytes, or all remanining bytes up to SecDir if
+	 * SecDir->Size is not 0.
+	 */
+	if (datasize > SumOfBytesHashed) {
 		hashbase = data + SumOfBytesHashed;
 		hashsize = datasize - context->SecDir->Size - SumOfBytesHashed;
 
 		if ((datasize - SumOfBytesHashed < context->SecDir->Size) ||
-		    (SumOfBytesHashed + hashsize != context->SecDir->VirtualAddress)) {
+		    (context->SecDir->Size && (SumOfBytesHashed + hashsize != context->SecDir->VirtualAddress))) {
 			perror(L"Malformed binary after Attribute Certificate Table\n");
 			console_print(L"datasize: %u SumOfBytesHashed: %u SecDir->Size: %lu\n",
 				      datasize, SumOfBytesHashed, context->SecDir->Size);


### PR DESCRIPTION
After hashing section contents, shim hashes extra data up until the
signature for a signed binary, but it ignores this extra data if the
binary is unsigned, calculating an incorrect PE hash. This fixes it
to include the extra data for unsigned images.

Should fix https://github.com/rhboot/shim/issues/337