### PR TITLE
arm/aa64: Swizzle some sections to make old sbsign happier.

### DIFF
--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -48,16 +48,38 @@ SECTIONS
    *(.dynbss)
    *(.bss)
    *(COMMON)
-   . = ALIGN(16);
+   . = ALIGN(4096);
    _bss_end = .;
   }
+  _edata = .;
+  _data_size = . - _data;
+
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+    . = ALIGN(4096);
+  }
+  _esbat = .;
+  _sbat_vsize = . - _sbat;
+  . = ALIGN(4096);
+  _sbat_size = . - _sbat;
 
   . = ALIGN(4096);
   .vendor_cert :
   {
+    _vendor_cert = .;
     *(.vendor_cert)
+    _evirt_vendor_cert = .;
+    . = ALIGN(4096);
   }
-  . = ALIGN(4096);
+  _evendor_cert = .;
+  _vendor_cert_vsize = _evirt_vendor_cert - _vendor_cert;
+  _vendor_cert_size = . - _vendor_cert;
+  _alldata_size = . - _data;
+
   .rela :
   {
     *(.rela.dyn)
@@ -66,20 +88,6 @@ SECTIONS
     *(.rela.data)
     *(.rela.data*)
   }
-  _edata = .;
-  _data_size = . - _data;
-  . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-  }
-  _esbat = .;
-  _sbat_vsize = . - _sbat;
-  . = ALIGN(4096);
-  _sbat_size = . - _sbat;
-  _alldata_size = . - _data;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -46,15 +46,38 @@ SECTIONS
    *(.dynbss)
    *(.bss)
    *(COMMON)
-   . = ALIGN(16);
+   . = ALIGN(4096);
    _bss_end = .;
   }
+  _edata = .;
+  _data_size = . - _data;
+
+  . = ALIGN(4096);
+  .sbat :
+  {
+    _sbat = .;
+    *(.sbat)
+    *(.sbat.*)
+    . = ALIGN(4096);
+  }
+  _esbat = .;
+  _sbat_vsize = . - _sbat;
+  . = ALIGN(4096);
+  _sbat_size = . - _sbat;
 
   . = ALIGN(4096);
   .vendor_cert :
   {
+    _vendor_cert = .;
     *(.vendor_cert)
+    _evirt_vendor_cert = .;
+    . = ALIGN(4096);
   }
+  _evendor_cert = .;
+  _vendor_cert_vsize = _evirt_vendor_cert - _vendor_cert;
+  _vendor_cert_size = . - _vendor_cert;
+  _alldata_size = . - _data;
+
   . = ALIGN(4096);
   .rel :
   {
@@ -64,20 +87,6 @@ SECTIONS
     *(.rel.data)
     *(.rel.data*)
   }
-  _edata = .;
-  _data_size = . - _data;
-  . = ALIGN(4096);
-  .sbat :
-  {
-    _sbat = .;
-    *(.sbat)
-    *(.sbat.*)
-  }
-  _esbat = .;
-  _sbat_vsize = . - _sbat;
-  . = ALIGN(4096);
-  _sbat_size = . - _sbat;
-  _alldata_size = . - _data;
 
   . = ALIGN(4096);
   .dynsym   : { *(.dynsym) }


### PR DESCRIPTION
xnox reports that with some versions of sbsign/sbcheck, it gets very
unhappy with non-contiguous sections and gaps between sections, which we
currently produce on targets with hand-coded headers.  This is all wrong
behavior from sbsigntools, and has been fixed in newer versions, but
nevertheless it's not hard for us to avoid.

This patch re-arranges the sections so there are no gaps, by padding the
file-size of .data and .sbat up to the full page, moving .sbat to be
before .vendor_cert, and moving .vendor_cert and .rela out of the range
covered by _edata, while still leaving included in the calculation of
SizeOfInitializedData.

Signed-off-by: Peter Jones <pjones@redhat.com>