### PR TITLE
Makefile: sort vendor sbats to remove duplicates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ sbat.%.csv : data/sbat.%.csv
 	$(DOS2UNIX) $(D2UFLAGS) $< $@
 	tail -c1 $@ | read -r _ || echo >> $@ # ensure a trailing newline
 
-VENDOR_SBATS := $(foreach x,$(wildcard $(TOPDIR)/data/sbat.*.csv data/sbat.*.csv),$(notdir $(x)))
+VENDOR_SBATS := $(sort $(foreach x,$(wildcard $(TOPDIR)/data/sbat.*.csv data/sbat.*.csv),$(notdir $(x))))
 
 sbat_data.o : | $(SBATPATH) $(VENDOR_SBATS)
 sbat_data.o : /dev/null


### PR DESCRIPTION
If no TOPDIR is defined and a vendor sbat CSV is placed in
$(BUILDDIR)/data/sbat.*.csv, objcopy fails with the following
error.

objcopy --add-section .sbat=/shim/data/sbat.csv \
        --set-section-flags .sbat=contents,alloc,load,readonly,data \
        sbat_data.o
objcopy --add-section ".sbat.microsoft=sbat.microsoft.csv" sbat_data.o
objcopy --add-section ".sbat.microsoft=sbat.microsoft.csv" sbat_data.o
objcopy:stuf2iKG: can't add section '.sbat.microsoft': bad value
make: *** [Makefile:120: sbat_data.o] Error 1

The sbat.vendor.csv is getting included twice in VENDOR_SBATS.

Use sort to ensure unique entries in VENDOR_SBATS

Signed-off-by: Chris Co <chrco@microsoft.com>