### PR TITLE
mok: allocate MOK config table as BootServicesData

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -1002,7 +1002,7 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 		npages = ALIGN_VALUE(config_sz, PAGE_SIZE) >> EFI_PAGE_SHIFT;
 		config_table = NULL;
 		efi_status = gBS->AllocatePages(AllocateAnyPages,
-						EfiRuntimeServicesData,
+						EfiBootServicesData,
 						npages,
 						(EFI_PHYSICAL_ADDRESS *)&config_table);
 		if (EFI_ERROR(efi_status) || !config_table) {


### PR DESCRIPTION
Linux kernel is picky when reserving the memory for x86 and it only
expects BootServicesData:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/arch/x86/platform/efi/quirks.c?h=v5.11#n254

Otherwise, the following error would show during system boot:

Apr 07 12:31:56.743925 localhost kernel: efi: Failed to lookup EFI memory descriptor for 0x000000003dcf8000

Although BootServicesData would be reclaimed after ExitBootService(),
linux kernel reserves MOK config table when it detects the existence of
the table, so it's fine to allocate the table as BootServicesData.

Signed-off-by: Gary Lin <glin@suse.com>