### PR TITLE
Allow modifications of overridden ARCH_LDFLAGS

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -84,7 +84,7 @@ ifeq ($(ARCH),aarch64)
 	ARCH_SUFFIX_UPPER	?= AA64
 	FORMAT			:= -O binary
 	SUBSYSTEM		:= 0xa
-	ARCH_LDFLAGS		+= --defsym=EFI_SUBSYSTEM=$(SUBSYSTEM)
+	override ARCH_LDFLAGS	+= --defsym=EFI_SUBSYSTEM=$(SUBSYSTEM)
 	ARCH_CFLAGS		?=
 	TIMESTAMP_LOCATION	:= 72
 endif
@@ -95,7 +95,7 @@ ifeq ($(ARCH),arm)
 	ARCH_SUFFIX_UPPER	?= ARM
 	FORMAT			:= -O binary
 	SUBSYSTEM		:= 0xa
-	ARCH_LDFLAGS		+= --defsym=EFI_SUBSYSTEM=$(SUBSYSTEM)
+	override ARCH_LDFLAGS	+= --defsym=EFI_SUBSYSTEM=$(SUBSYSTEM)
 	TIMESTAMP_LOCATION	:= 72
 endif
 


### PR DESCRIPTION
Add "override" directive so ARCH_LDFLAGS that is passed as
an argument to make(1) can be modified by += operator for
ARM and ARM64 platforms. Without this directive only passed
value is used and --defsym.. part is not passed to ld(1).

Signed-off-by: Oleksandr Tymoshenko <ovt@google.com>