### PR TITLE
lds: remove note.gnu.build-id from most places, move to the end.

### DIFF
--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -80,8 +80,6 @@ SECTIONS
     *(.srodata)
     *(.dynsym)
     *(.dynstr)
-    . = ALIGN(16);
-    *(.note.gnu.build-id)
     . = ALIGN(4096);
     *(.vendor_cert)
     *(.data.ident)
@@ -100,4 +98,5 @@ SECTIONS
     *(.note.GNU-stack)
   }
   .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
 }

--- a/elf_arm_efi.lds
+++ b/elf_arm_efi.lds
@@ -80,8 +80,6 @@ SECTIONS
     *(.srodata)
     *(.dynsym)
     *(.dynstr)
-    . = ALIGN(16);
-    *(.note.gnu.build-id)
     . = ALIGN(4096);
     *(.vendor_cert)
     *(.data.ident)
@@ -100,4 +98,5 @@ SECTIONS
     *(.note.GNU-stack)
   }
   .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
 }

--- a/elf_ia32_efi.lds
+++ b/elf_ia32_efi.lds
@@ -92,4 +92,5 @@ SECTIONS
     *(.note.GNU-stack)
   }
   .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
 }

--- a/elf_ia64_efi.lds
+++ b/elf_ia64_efi.lds
@@ -27,10 +27,6 @@ SECTIONS
    *(.sbss)
    *(.scommon)
   }
-  . = ALIGN(4096);
-  .note.gnu.build-id : {
-    *(.note.gnu.build-id)
-  }
   .data.ident : {
     *(.data.ident)
   }

--- a/elf_x86_64_efi.lds
+++ b/elf_x86_64_efi.lds
@@ -27,11 +27,6 @@ SECTIONS
    *(.reloc)
   }
   . = ALIGN(4096);
-  .note.gnu.build-id : {
-    *(.note.gnu.build-id)
-  }
-
-  . = ALIGN(4096);
   .data.ident : {
     *(.data.ident)
   }


### PR DESCRIPTION
.note.gnu.build-id was included in rodata sections on some
architectures, which get added to the elf .so & debug .so, but are not
copied into pe binary. Unless of course this section was embeeded
inside the .rodata.

Remove embedded copies of build-id, move build-id to the end of the
elf binaries. Note that stability and reproducibility of build-id note
is not needed, as most distributions strip & replace build-id with a
rebuilt one based on package name & version.

Fixes #366 (point 2)

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>