### PR TITLE
Relax the check for import_mok_state()

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1973,10 +1973,13 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	 * boot-services-only state variables are what we think they are.
 	 */
 	efi_status = import_mok_state(image_handle);
-	if (!secure_mode() && efi_status == EFI_INVALID_PARAMETER) {
+	if (!secure_mode() &&
+	    (efi_status == EFI_INVALID_PARAMETER ||
+	     efi_status == EFI_OUT_OF_RESOURCES)) {
 		/*
 		 * Make copy failures fatal only if secure_mode is enabled, or
-		 * the error was anything else than EFI_INVALID_PARAMETER.
+		 * the error was anything else than EFI_INVALID_PARAMETER or
+		 * EFI_OUT_OF_RESOURCES.
 		 * There are non-secureboot firmware implementations that don't
 		 * reserve enough EFI variable memory to fit the variable.
 		 */


### PR DESCRIPTION
An openSUSE user reported(*) that shim 15.4 failed to boot the system
with the following message:

  "Could not create MokListXRT: Out of Resources"

In the beginning, I thought it's caused by the growing size of
vendor-dbx. However, we found the following messages after set
SHIM_VERBOSE:

  max_var_sz:8000 remaining_sz:85EC max_storage_sz:9000
  SetVariable(“MokListXRT”, ... varsz=0x1404) = Out of Resources

Even though the firmware claimed the remaining storage size is 0x85EC
and the maximum variable size is 0x8000, it still rejected MokListXRT
with size 0x1404. It seems that the return values from QueryVariableInfo()
are not reliable. Since this firmware didn't really support Secure Boot,
the variable mirroring is not so critical, so we can just accept the
failure of import_mok_state() and continue boot.

(*) https://bugzilla.suse.com/show_bug.cgi?id=1185261

Signed-off-by: Gary Lin <glin@suse.com>