### PR TITLE
BUG/RFE: more set_second_stage() fixes and improvements

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1558,13 +1558,20 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 		UINT16 *cur = li->LoadOptions;
 		for (i = 1; i < li->LoadOptionsSize / 2; i++) {
 			if (cur[i - 1] == L'\0') {
-				start = &cur[i];
-				remaining_size = li->LoadOptionsSize - (i * 2);
-				break;
+				if (start == li->LoadOptions) {
+					start = &cur[i];
+					loader_len = li->LoadOptionsSize - (i * 2);
+					remaining_size = 0;
+				} else {
+					loader_len = (&cur[i] - start) * 2;
+					remaining_size = li->LoadOptionsSize - (i * 2);
+					break;
+				}
 			}
 		}
-
-		remaining_size -= i * 2 + 2;
+		/* if we didn't find at least one NULL, something is wrong */
+		if (start == li->LoadOptions)
+			return EFI_SUCCESS;
 	} else if (strings == 1 && is_our_path(li, start)) {
 		/*
 		 * And then I found a version of BDS that gives us our own path


### PR DESCRIPTION
*NOTE: This PR is against `shim-15.4` since that is what we are concerned with, but it should also apply to the default branch.*

This PR has two patches: the first fixes a regression in the shim argument parsing, the second adds the ability to handle a single UCS-2 string passed as an argument.  Both patches have been tested on modern QEMU+OVMF and Cisco UCS systems (physical hardware).  Please see each patch description for more information.
