### PR TITLE
Fix load option regression

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1388,7 +1388,7 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 	EFI_STATUS efi_status;
 	EFI_LOADED_IMAGE *li = NULL;
 	CHAR16 *start = NULL;
-	UINTN remaining_size = 0;
+	int remaining_size = 0;
 	CHAR16 *loader_str = NULL;
 	UINTN loader_len = 0;
 	unsigned int i;
@@ -1510,14 +1510,9 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 					   li->LoadOptionsSize);
 
 	/*
-	 * In some cases we get strings == 1 because BDS is using L' ' as the
-	 * delimeter:
-	 * 0000:74 00 65 00 73 00 74 00 2E 00 65 00 66 00 69 00 t.e.s.t...e.f.i.
-	 * 0016:20 00 6F 00 6E 00 65 00 20 00 74 00 77 00 6F 00 ..o.n.e...t.w.o.
-	 * 0032:20 00 74 00 68 00 72 00 65 00 65 00 00 00       ..t.h.r.e.e...
-	 *
-	 * If so replace it with NULs since the code already handles that
-	 * case.
+	 * In the case where strings == 1 check to see if L' ' is being used as
+	 * a delimiter, if so replace it with NULLs since the code already
+	 * handles that case.
 	 */
 	if (strings == 1) {
 		UINT16 *cur = start = li->LoadOptions;
@@ -1563,12 +1558,18 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 				break;
 			}
 		}
+		/* if we didn't find at least one NULL, something is wrong */
+		if (start == li->LoadOptions)
+			return EFI_SUCCESS;
 
-		remaining_size -= i * 2 + 2;
+		while (start[loader_len++] != L'\0');
+		loader_len *= 2;
+
+		remaining_size -= loader_len;
 	} else if (strings == 1 && is_our_path(li, start)) {
 		/*
-		 * And then I found a version of BDS that gives us our own path
-		 * in LoadOptions:
+		* And then I found a version of BDS that gives us our own path
+		* in LoadOptions:
 
 77162C58                           5c 00 45 00 46 00 49 00          |\.E.F.I.|
 77162C60  5c 00 42 00 4f 00 4f 00  54 00 5c 00 42 00 4f 00  |\.B.O.O.T.\.B.O.|

--- a/shim.c
+++ b/shim.c
@@ -1550,7 +1550,7 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 		 * LoadOptions.  We ignore the string before the first L'\0',
 		 * i.e. the name of this program.
 		 */
-		UINT16 *cur = li->LoadOptions;
+		UINT16 *cur = start = li->LoadOptions;
 		for (i = 1; i < li->LoadOptionsSize / 2; i++) {
 			if (cur[i - 1] == L'\0') {
 				start = &cur[i];


### PR DESCRIPTION
Alternative to #374 and #379 that just reverts the flawed commit and then initializes the start variable as it does in the previous code path in `if`