### PR TITLE
BUG/RFE: more set_second_stage() fixes and improvements (revised/rebased against "main")

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1545,7 +1545,8 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 		opts = li->LoadOptions;
 
 	/*
-	 * If it's not string data, try it as an EFI_LOAD_OPTION.
+	 * Try to parse the LoadOptions as either a EFI_LOAD_OPTION or as
+	 * a variable number of UCS-2 strings.  Wish us luck.
 	 */
 	if (strings == 0) {
 		/*
@@ -1559,6 +1560,24 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 		if (EFI_ERROR(efi_status))
 			return EFI_SUCCESS;
 
+		remaining_size = 0;
+	} else if (strings == 1) {
+		start = li->LoadOptions;
+		if (is_our_path(li, start)) {
+			/*
+			 * I found a version of BDS that gives us our own path
+			 * in LoadOptions:
+77162C58                           5c 00 45 00 46 00 49 00          |\.E.F.I.|
+77162C60  5c 00 42 00 4f 00 4f 00  54 00 5c 00 42 00 4f 00  |\.B.O.O.T.\.B.O.|
+77162C70  4f 00 54 00 58 00 36 00  34 00 2e 00 45 00 46 00  |O.T.X.6.4...E.F.|
+77162C80  49 00 00 00                                       |I...|
+			 * which is just cruel... So yeah, just don't use it.
+			 */
+			return EFI_SUCCESS;
+		}
+
+		/* assume this string is the second stage loader */
+		loader_len = li->LoadOptionsSize;
 		remaining_size = 0;
 	} else if (strings >= 2) {
 		/*
@@ -1587,19 +1606,9 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 		/* if we didn't find at least one NULL, something is wrong */
 		if (start == li->LoadOptions)
 			return EFI_SUCCESS;
-	} else if (strings == 1 && is_our_path(li, start)) {
-		/*
-		 * And then I found a version of BDS that gives us our own path
-		 * in LoadOptions:
-
-77162C58                           5c 00 45 00 46 00 49 00          |\.E.F.I.|
-77162C60  5c 00 42 00 4f 00 4f 00  54 00 5c 00 42 00 4f 00  |\.B.O.O.T.\.B.O.|
-77162C70  4f 00 54 00 58 00 36 00  34 00 2e 00 45 00 46 00  |O.T.X.6.4...E.F.|
-77162C80  49 00 00 00                                       |I...|
-
-		* which is just cruel... So yeah, just don't use it.
-		*/
-		return EFI_SUCCESS;
+	} else {
+		/* fallback to the default loader */
+		loader_len = 0;
 	}
 
 	/* cleanup if we create a duplicate li->LoadOptions */


### PR DESCRIPTION
*NOTE: This is an update of PR #374 to rebase against `main` instead of `shim-15.4` as well as address some of the issues in the previous PR.*

This PR has two patches: the first fixes a regression in the shim argument parsing, the second adds the ability to handle a single UCS-2 string passed as an argument. Both patches have been tested on modern QEMU+OVMF and Cisco UCS systems (physical hardware). Please see each patch description for more information.