### PR TITLE
mok: skip the empty variables when copying the data to MOK config table

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -1028,16 +1028,18 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 	for (i = 0; p && mok_state_variables[i].name != NULL; i++) {
 		struct mok_state_variable *v = &mok_state_variables[i];
 
-		ZeroMem(&config_template, sizeof(config_template));
-		strncpy(config_template.name, (CHAR8 *)v->rtname8, 255);
-		config_template.name[255] = '\0';
+		if (v->data && v->data_size) {
+			ZeroMem(&config_template, sizeof(config_template));
+			strncpy(config_template.name, (CHAR8 *)v->rtname8, 255);
+			config_template.name[255] = '\0';
 
-		config_template.data_size = v->data_size;
+			config_template.data_size = v->data_size;
 
-		CopyMem(p, &config_template, sizeof(config_template));
-		p += sizeof(config_template);
-		CopyMem(p, v->data, v->data_size);
-		p += v->data_size;
+			CopyMem(p, &config_template, sizeof(config_template));
+			p += sizeof(config_template);
+			CopyMem(p, v->data, v->data_size);
+			p += v->data_size;
+		}
 	}
 	if (p) {
 		ZeroMem(&config_template, sizeof(config_template));


### PR DESCRIPTION
When calculating the size of the MOK config table, we skip the empty
variables. However, when copying the data, we copied the zeroed config
templates for those empty variables, and this could cause crash since we
may write more data than the allocated pages. This commit skips the
empty variables when copying the data so that the size of copied data
matches config_sz.

Signed-off-by: Gary Lin <glin@suse.com>