### PR TITLE
shim: Reset console when loading shim

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1483,6 +1483,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	 * Ensure that gnu-efi functions are available
 	 */
 	InitializeLib(image_handle, systab);
+	console_mode_handle();
 	setup_verbosity();
 
 	dprint(L"vendor_authorized:0x%08lx vendor_authorized_size:%lu\n",


### PR DESCRIPTION
This allows the firmware in some systems (including my own, MSI MAG X570) to automatically configure the native resolution for the console instead of a default low resolution.