### PR TITLE
httpboot: Ignore case when checking HTTP headers

### DIFF
--- a/httpboot.c
+++ b/httpboot.c
@@ -571,7 +571,8 @@ receive_http_response(EFI_HTTP_PROTOCOL *http, VOID **buffer, UINT64 *buf_size)
 
 	/* Check the length of the file */
 	for (i = 0; i < rx_message.HeaderCount; i++) {
-		if (!strcmp(rx_message.Headers[i].FieldName, (CHAR8 *)"Content-Length")) {
+		if (!strcasecmp(rx_message.Headers[i].FieldName,
+				(CHAR8 *)"Content-Length")) {
 			*buf_size = ascii_to_int(rx_message.Headers[i].FieldValue);
 		}
 	}


### PR DESCRIPTION
Some servers (HAProxy) yield Content-Length in lowercase, and shim would
fail to find it.

Signed-off-by: Robbie Harwood <rharwood@redhat.com>