### PR TITLE
csv: detect end of csv file correctly

### DIFF
--- a/csv.c
+++ b/csv.c
@@ -15,6 +15,7 @@ parse_csv_line(char * line, size_t max, size_t *n_columns, const char *columns[]
 	char *token = NULL;
 
 	bool valid = true;
+
 	for (n = 0; n < *n_columns; n++) {
 
 		if (valid) {
@@ -62,16 +63,17 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 	}
 
 	max = (uintptr_t)end - (uintptr_t)line + (end > line ? 1 : 0);
+	if (is_utf8_bom(line, max))
 
-	if (line && is_utf8_bom(line, max))
 		line += UTF8_BOM_SIZE;
 
-	while (line && line <= data_end) {
+	while (line <= data_end && *line) {
 		size_t entrysz = sizeof(char *) * n_columns + sizeof(struct csv_row);
 		struct csv_row *entry;
 		size_t m_columns = n_columns;
 		char *delim;
 		bool found = true;
+		bool eof = false;
 
 		end = data_end;
 		max = (uintptr_t)end - (uintptr_t)line + (end > line ? 1 : 0);
@@ -91,6 +93,9 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 				end = tmp;
 		}
 		max = (uintptr_t)end - (uintptr_t)line + (end > line ? 1 : 0);
+
+		if (!*end)
+			eof = true;
 		*end = '\0';
 
 		if (line == data_end || max == 0) {
@@ -115,6 +120,9 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 
 		parse_csv_line(line, max, &m_columns, (const char **)entry->columns);
 		entry->n_columns = m_columns;
+		if (eof)
+			break;
+
 		line = end + 1;
 	}
 

--- a/csv.c
+++ b/csv.c
@@ -77,6 +77,7 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 
 		end = data_end;
 		max = (uintptr_t)end - (uintptr_t)line + (end > line ? 1 : 0);
+		/* Skip the delimiter(s) of the previous line */
 		while (max && found) {
 			found = false;
 			for (delim = &delims[0]; max && *delim; delim++) {
@@ -87,6 +88,7 @@ parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 				}
 			}
 		}
+		/* Find the first delimiter of the current line */
 		for (delim = &delims[0]; *delim; delim++) {
 			char *tmp = strnchrnul(line, max, *delim);
 			if (tmp < end)

--- a/test-csv.c
+++ b/test-csv.c
@@ -338,6 +338,68 @@ fail:
 }
 
 int
+test_csv_3(void)
+{
+	char csv[] =
+		"a,b,c,d,e,f,g,h\n"
+		"a,b,c\n"
+		"\n"
+		"\n"
+		"a,b,c,d,e,f,g,h\n"
+		"a,b,c\0x,y\0z\0";
+	struct test_entry test_entries[]= {
+		{ 7, { "a", "b", "c", "d", "e", "f", "g" } },
+		{ 3, { "a", "b", "c", NULL, NULL, NULL, NULL } },
+		{ 7, { "a", "b", "c", "d", "e", "f", "g" } },
+		{ 3, { "a", "b", "c", NULL, NULL, NULL, NULL } },
+	};
+	list_t entry_list;
+	size_t i;
+	char *current, *end;
+	list_t *pos = NULL;
+	EFI_STATUS efi_status;
+
+	INIT_LIST_HEAD(&entry_list);
+	assert_equal_return(list_size(&entry_list), 0, -1,
+			    "got %d expected %d\n");
+
+	current = csv;
+	end = csv + sizeof(csv) - 1;
+
+	efi_status = parse_csv_data(current, end, 7, &entry_list);
+	assert_equal_return(efi_status, EFI_SUCCESS, -1, "got %x expected %x\n");
+
+	i = 0;
+	list_for_each(pos, &entry_list) {
+		struct csv_row *csv_row;
+		struct test_entry *test_entry = &test_entries[i++];
+		size_t j;
+
+		assert_goto(i > 0 && i <= 4, fail, "got %d expected 0 to 4\n", i);
+
+		csv_row = list_entry(pos, struct csv_row, list);
+
+		assert_equal_goto(csv_row->n_columns, test_entry->n_columns,
+				  fail, "got %d expected %d\n");
+		for (j = 0; j < csv_row->n_columns; j++) {
+			assert_equal_goto(strcmp(csv_row->columns[j],
+					   test_entry->columns[j]), 0,
+				    fail, "got %d expected %d\n");
+		}
+	}
+
+	assert_equal_return(list_size(&entry_list), 4, -1,
+			    "got %d expected %d\n");
+	free_csv_list(&entry_list);
+	assert_equal_return(list_size(&entry_list), 0, -1,
+			    "got %d expected %d\n");
+	return 0;
+fail:
+	free_csv_list(&entry_list);
+	return -1;
+}
+
+int
 test_simple_sbat_csv(void)
 {
 	char csv[] =
@@ -456,6 +518,7 @@ main(void)
 	test(test_csv_0);
 	test(test_csv_1);
 	test(test_csv_2);
+	test(test_csv_3);
 	test(test_simple_sbat_csv);
 	test(test_csv_simple_fuzz, random_bin, random_bin_len, false);
 	for (i = 0; i < random_bin_len; i++) {


### PR DESCRIPTION
.sbat sections contain user supplied data. We should not assume that it is
well formed. The last line feed might be missing or it might not be at the 
end of the file. Instead one or more \0 might follow.

In parse_csv_data() variable 'line' is a pointer with a value between
the values of 'data' and 'data_end'.

There is no reason to check that it is non-zero after assigning it
from 'data' as we already check 'data'.

Instead at the beginning of the file and after each line we must check that
we have not reached the end of the file marked by a '\0' character.
