### PR TITLE
fallback: incorrect check after AllocateZeroPool()

### DIFF
--- a/fallback.c
+++ b/fallback.c
@@ -158,7 +158,7 @@ read_file(EFI_FILE_HANDLE fh, CHAR16 *fullpath, CHAR16 **buffer, UINT64 *bs)
 	}
 
 	b = AllocateZeroPool(len + 2);
-	if (!buffer) {
+	if (!b) {
 		console_print(L"Could not allocate memory\n");
 		fh2->Close(fh2);
 		return EFI_OUT_OF_RESOURCES;


### PR DESCRIPTION
After calling AllocateZeroPool() we must check the returned pointer.

Fixes: 3ce517fdbb4e ("Add a fallback loader for when shim is invoked as BOOTX64.EFI")
Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>