### PR TITLE
str: remove duplicate parameter check

### DIFF
--- a/include/str.h
+++ b/include/str.h
@@ -72,8 +72,6 @@ strntoken(char *str, size_t max, const char *delims, char **token, char *state)
 		return 0;
 
 	tokend = &str[max-1];
-	if (!str || max == 0 || !delims || !token)
-		return 0;
 
 	/*
 	 * the very special case of "" with max=1, where we have no prior


### PR DESCRIPTION
There is no need to check the parameters of strntoken() twice.

Fixes: c7bb10cf154a ("Tidy up our string primitives...")
Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>