### PR TITLE
tests: add "include-fixed" GCC directory to include directories

### DIFF
--- a/include/test.mk
+++ b/include/test.mk
@@ -46,6 +46,10 @@ CFLAGS = $(OPTIMIZATIONS) -std=gnu11 \
 	 -DSHIM_UNIT_TEST \
 	 "-DDEFAULT_DEBUG_PRINT_STATE=$(DEBUG_PRINTS)"
 
+# On some systems (e.g. Arch Linux), limits.h is in the "include-fixed" instead
+# of the "include" directory
+CFLAGS += -isystem $(shell $(CC) $(ARCH_CFLAGS) -print-file-name=include-fixed)
+
 export CFLAGS_LTO CFLAGS_GCOV
 
 libefi-test.a :


### PR DESCRIPTION
On Arch Linux, the GCC version of `limits.h` is in the `include-fixed` instead of the `include` directory. It needs to be included in the include directories list, otherwise attempting to compile the test suite fails with the following error:
```
In file included from /usr/include/efivar/efivar-dp.h:22,
                 from /usr/include/efivar/efivar.h:238,
                 from include/test.h:51,
                 from shim.h:68,
                 from csv.c:6:
/usr/include/limits.h:124:16: fatal error: limits.h: No such file or directory
  124 | # include_next <limits.h>
      |                ^~~~~~~~~~
compilation terminated.
```