### PR TITLE
docs: update SBAT UEFI variable name

### DIFF
--- a/SBAT.example.md
+++ b/SBAT.example.md
@@ -16,7 +16,7 @@ the `.sbat` section has the following fields:
 
 `SBAT` EFI variable
 -----------------
-The SBAT EFI variable (`SBAT-605dab50-e046-4300-abb6-3dd810dd8b23`) is structured as a series ASCII CSV records:
+The SBAT EFI variable (`SbatLevel-605dab50-e046-4300-abb6-3dd810dd8b23`) is structured as a series ASCII CSV records:
 
 ```
 sbat,1


### PR DESCRIPTION
The name of the SBAT UEFI variable changed from "SBAT" to "SbatLevel" in
27da4170f0fb30acde91a37e0256dfcfe76ea69e. Update the documentation to match.

Signed-off-by: Nicholas Bishop <nicholasbishop@google.com>