### PR TITLE
Fix a component version in SBAT.example.md

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -45,6 +45,12 @@ Variables you could set to customize the build:
   shim has already verified the kernel when shim loaded the kernel as the
   second stage loader.  In such a case, and only in this case, you should
   use DISABLE_EBS_PROTECTION=y to build.
+- DISABLE_REMOVABLE_LOAD_OPTIONS
+  Do not parse load options when invoked as boot*.efi. This prevents boot
+  failures because of unexpected data in boot entries automatically generated
+  by firmware. It breaks loading non-default second-stage loaders when invoked
+  via that path, and requires using a binary named shim*.efi (or really anything
+  else).
 - REQUIRE_TPM
   if tpm logging or extends return an error code, treat that as a fatal error.
 - ARCH

--- a/Make.defaults
+++ b/Make.defaults
@@ -153,6 +153,10 @@ ifneq ($(origin DISABLE_EBS_PROTECTION), undefined)
 	DEFINES  += -DDISABLE_EBS_PROTECTION
 endif
 
+ifneq ($(origin DISABLE_REMOVABLE_LOAD_OPTIONS), undefined)
+	DEFINES  += -DDISABLE_REMOVABLE_LOAD_OPTIONS
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --target efi-app-$(ARCH)

--- a/SBAT.example.md
+++ b/SBAT.example.md
@@ -192,7 +192,7 @@ Debian discovers that they actually shipped bug 0 as well (woops).  They
 produce a new build which fixes it and has the following in `.sbat`:
 ```
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-grub,1,Free Software Foundation,grub,2.04,https://www.gnu.org/software/grub/
+grub,2,Free Software Foundation,grub,2.04,https://www.gnu.org/software/grub/
 grub.debian,2,Debian,grub2,2.04-13,https://packages.debian.org/source/sid/grub2
 ```
 

--- a/lib/console.c
+++ b/lib/console.c
@@ -122,6 +122,30 @@ console_print_at(UINTN col, UINTN row, const CHAR16 *fmt, ...)
 	return ret;
 }
 
+static struct {
+	CHAR16 up_left;
+	CHAR16 up_right;
+	CHAR16 down_left;
+	CHAR16 down_right;
+	CHAR16 horizontal;
+	CHAR16 vertical;
+} boxdraw[2] = {
+	{
+		BOXDRAW_UP_LEFT,
+		BOXDRAW_UP_RIGHT,
+		BOXDRAW_DOWN_LEFT,
+		BOXDRAW_DOWN_RIGHT,
+		BOXDRAW_HORIZONTAL,
+		BOXDRAW_VERTICAL
+	}, {
+		'+',
+		'+',
+		'+',
+		'+',
+		'-',
+		'|'
+	}
+};
 
 void
 console_print_box_at(CHAR16 *str_arr[], int highlight,
@@ -133,6 +157,7 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
 	UINTN rows, cols;
 	CHAR16 *Line;
+	bool char_set;
 
 	if (lines == 0)
 		return;
@@ -181,10 +206,16 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 		return;
 	}
 
-	SetMem16 (Line, size_cols * 2, BOXDRAW_HORIZONTAL);
+	/* test if boxdraw characters work */
+	co->SetCursorPosition(co, start_col, start_row);
+	Line[0] = boxdraw[0].up_left;
+	Line[1] = L'\0';
+	char_set = co->OutputString(co, Line) == 0 ? 0 : 1;
 
-	Line[0] = BOXDRAW_DOWN_RIGHT;
-	Line[size_cols - 1] = BOXDRAW_DOWN_LEFT;
+	SetMem16 (Line, size_cols * 2, boxdraw[char_set].horizontal);
+
+	Line[0] = boxdraw[char_set].down_right;
+	Line[size_cols - 1] = boxdraw[char_set].down_left;
 	Line[size_cols] = L'\0';
 	co->SetCursorPosition(co, start_col, start_row);
 	co->OutputString(co, Line);
@@ -204,8 +235,8 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 		int line = i - start;
 
 		SetMem16 (Line, size_cols*2, L' ');
-		Line[0] = BOXDRAW_VERTICAL;
-		Line[size_cols - 1] = BOXDRAW_VERTICAL;
+		Line[0] = boxdraw[char_set].vertical;
+		Line[size_cols - 1] = boxdraw[char_set].vertical;
 		Line[size_cols] = L'\0';
 		if (line >= 0 && line < lines) {
 			CHAR16 *s = str_arr[line];
@@ -227,9 +258,9 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 					       EFI_BACKGROUND_BLUE);
 
 	}
-	SetMem16 (Line, size_cols * 2, BOXDRAW_HORIZONTAL);
-	Line[0] = BOXDRAW_UP_RIGHT;
-	Line[size_cols - 1] = BOXDRAW_UP_LEFT;
+	SetMem16 (Line, size_cols * 2, boxdraw[char_set].horizontal);
+	Line[0] = boxdraw[char_set].up_right;
+	Line[size_cols - 1] = boxdraw[char_set].up_left;
 	Line[size_cols] = L'\0';
 	co->SetCursorPosition(co, start_col, i);
 	co->OutputString(co, Line);

--- a/shim.c
+++ b/shim.c
@@ -690,24 +690,11 @@ verify_buffer (char *data, int datasize,
 }
 
 static int
-should_use_fallback(EFI_HANDLE image_handle)
+is_removable_media_path(EFI_LOADED_IMAGE *li)
 {
-	EFI_LOADED_IMAGE *li;
 	unsigned int pathlen = 0;
 	CHAR16 *bootpath = NULL;
-	EFI_FILE_IO_INTERFACE *fio = NULL;
-	EFI_FILE *vh = NULL;
-	EFI_FILE *fh = NULL;
-	EFI_STATUS efi_status;
 	int ret = 0;
-
-	efi_status = BS->HandleProtocol(image_handle, &EFI_LOADED_IMAGE_GUID,
-					(void **)&li);
-	if (EFI_ERROR(efi_status)) {
-		perror(L"Could not get image for boot" EFI_ARCH L".efi: %r\n",
-		       efi_status);
-		return 0;
-	}
 
 	bootpath = DevicePathToStr(li->FilePath);
 
@@ -724,6 +711,36 @@ should_use_fallback(EFI_HANDLE image_handle)
 
 	pathlen = StrLen(bootpath);
 	if (pathlen < 5 || StrCaseCmp(bootpath + pathlen - 4, L".EFI"))
+		goto error;
+
+	ret = 1;
+
+error:
+	if (bootpath)
+		FreePool(bootpath);
+
+	return ret;
+}
+
+static int
+should_use_fallback(EFI_HANDLE image_handle)
+{
+	EFI_LOADED_IMAGE *li;
+	EFI_FILE_IO_INTERFACE *fio = NULL;
+	EFI_FILE *vh = NULL;
+	EFI_FILE *fh = NULL;
+	EFI_STATUS efi_status;
+	int ret = 0;
+
+	efi_status = BS->HandleProtocol(image_handle, &EFI_LOADED_IMAGE_GUID,
+	                                (void **)&li);
+	if (EFI_ERROR(efi_status)) {
+		perror(L"Could not get image for boot" EFI_ARCH L".efi: %r\n",
+		       efi_status);
+		return 0;
+	}
+
+	if (!is_removable_media_path(li))
 		goto error;
 
 	efi_status = BS->HandleProtocol(li->DeviceHandle, &FileSystemProtocol,
@@ -758,12 +775,9 @@ error:
 		fh->Close(fh);
 	if (vh)
 		vh->Close(vh);
-	if (bootpath)
-		FreePool(bootpath);
 
 	return ret;
 }
-
 /*
  * Open the second stage bootloader and read it into a buffer
  */

--- a/shim.c
+++ b/shim.c
@@ -1170,6 +1170,17 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 		return efi_status;
 	}
 
+#if defined(DISABLE_REMOVABLE_LOAD_OPTIONS)
+	/*
+	 * boot services build very strange load options, and we might misparse them,
+	 * causing boot failures on removable media.
+	 */
+	if (is_removable_media_path(li)) {
+		dprint("Invoked from removable media path, ignoring boot options");
+		return EFI_SUCCESS;
+	}
+#endif
+
 	efi_status = parse_load_options(li);
 	if (EFI_ERROR(efi_status)) {
 		perror (L"Failed to get load options: %r\n", efi_status);


### PR DESCRIPTION
In the bug2 section, the first Debian `.sbat` has a `grub,1`
component. But at this point in the story, `grub,1` has been revoked by
the update in the bug1 section. Updated it to `grub,2` so that it passes
that check.