### PR TITLE
Use ASCII as fallback if Unicode Box Drawing characters fail

### DIFF
--- a/lib/console.c
+++ b/lib/console.c
@@ -122,6 +122,30 @@ console_print_at(UINTN col, UINTN row, const CHAR16 *fmt, ...)
 	return ret;
 }
 
+static struct {
+	CHAR16 up_left;
+	CHAR16 up_right;
+	CHAR16 down_left;
+	CHAR16 down_right;
+	CHAR16 horizontal;
+	CHAR16 vertical;
+} boxdraw[2] = {
+	{
+		BOXDRAW_UP_LEFT,
+		BOXDRAW_UP_RIGHT,
+		BOXDRAW_DOWN_LEFT,
+		BOXDRAW_DOWN_RIGHT,
+		BOXDRAW_HORIZONTAL,
+		BOXDRAW_VERTICAL
+	}, {
+		'+',
+		'+',
+		'+',
+		'+',
+		'-',
+		'|'
+	}
+};
 
 void
 console_print_box_at(CHAR16 *str_arr[], int highlight,
@@ -133,6 +157,7 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 	SIMPLE_TEXT_OUTPUT_INTERFACE *co = ST->ConOut;
 	UINTN rows, cols;
 	CHAR16 *Line;
+	bool char_set;
 
 	if (lines == 0)
 		return;
@@ -181,10 +206,16 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 		return;
 	}
 
-	SetMem16 (Line, size_cols * 2, BOXDRAW_HORIZONTAL);
+	/* test if boxdraw characters work */
+	co->SetCursorPosition(co, start_col, start_row);
+	Line[0] = boxdraw[0].up_left;
+	Line[1] = L'\0';
+	char_set = co->OutputString(co, Line) == 0 ? 0 : 1;
 
-	Line[0] = BOXDRAW_DOWN_RIGHT;
-	Line[size_cols - 1] = BOXDRAW_DOWN_LEFT;
+	SetMem16 (Line, size_cols * 2, boxdraw[char_set].horizontal);
+
+	Line[0] = boxdraw[char_set].down_right;
+	Line[size_cols - 1] = boxdraw[char_set].down_left;
 	Line[size_cols] = L'\0';
 	co->SetCursorPosition(co, start_col, start_row);
 	co->OutputString(co, Line);
@@ -204,8 +235,8 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 		int line = i - start;
 
 		SetMem16 (Line, size_cols*2, L' ');
-		Line[0] = BOXDRAW_VERTICAL;
-		Line[size_cols - 1] = BOXDRAW_VERTICAL;
+		Line[0] = boxdraw[char_set].vertical;
+		Line[size_cols - 1] = boxdraw[char_set].vertical;
 		Line[size_cols] = L'\0';
 		if (line >= 0 && line < lines) {
 			CHAR16 *s = str_arr[line];
@@ -227,9 +258,9 @@ console_print_box_at(CHAR16 *str_arr[], int highlight,
 					       EFI_BACKGROUND_BLUE);
 
 	}
-	SetMem16 (Line, size_cols * 2, BOXDRAW_HORIZONTAL);
-	Line[0] = BOXDRAW_UP_RIGHT;
-	Line[size_cols - 1] = BOXDRAW_UP_LEFT;
+	SetMem16 (Line, size_cols * 2, boxdraw[char_set].horizontal);
+	Line[0] = boxdraw[char_set].up_right;
+	Line[size_cols - 1] = boxdraw[char_set].up_left;
 	Line[size_cols] = L'\0';
 	co->SetCursorPosition(co, start_col, i);
 	co->OutputString(co, Line);


### PR DESCRIPTION
This is https://github.com/rhboot/shim/pull/271 all over again, because I realized I shouldn't have pushed anything to rhboot/main until shim-15.5 is released.