### PR TITLE
fallback: fix fallback not passing arguments of the first boot option

### DIFF
--- a/fallback.c
+++ b/fallback.c
@@ -248,7 +248,7 @@ add_boot_option(EFI_DEVICE_PATH *hddp, EFI_DEVICE_PATH *fulldp,
 
 			if (!first_new_option) {
 				first_new_option = DuplicateDevicePath(fulldp);
-				first_new_option_args = arguments;
+				first_new_option_args = StrDuplicate(arguments);
 				first_new_option_size = StrLen(arguments) * sizeof (CHAR16);
 			}
 
@@ -482,7 +482,7 @@ find_boot_option(EFI_DEVICE_PATH *dp, EFI_DEVICE_PATH *fulldp,
 		/* at this point, we have duplicate data. */
 		if (!first_new_option) {
 			first_new_option = DuplicateDevicePath(fulldp);
-			first_new_option_args = arguments;
+			first_new_option_args = StrDuplicate(arguments);
 			first_new_option_size = StrLen(arguments) * sizeof (CHAR16);
 		}
 


### PR DESCRIPTION
The buffer used to read the data in the CSV is declared as a stack variable
in the try_boot_csv() function, but a pointer to the arguments field of the
first boot option is stored in the global first_new_option_args variable.

Later, when is used set the arguments to boot the first entry, the variable
points to memory that no longer exists. This leads to booting an entry with
garbage as arguments instead of the correct value.

Reported-by: Alexander Larsson <alexl@redhat.com>
Signed-off-by: Javier Martinez Canillas <javierm@redhat.com>