### PR TITLE
MokManager: removed Locate graphic output protocol fail error message

### DIFF
--- a/lib/console.c
+++ b/lib/console.c
@@ -522,7 +522,6 @@ console_mode_handle(VOID)
 
 	efi_status = BS->LocateProtocol(&gop_guid, NULL, (void **)&gop);
 	if (EFI_ERROR(efi_status)) {
-		console_error(L"Locate graphic output protocol fail", efi_status);
 		return;
 	}
 


### PR DESCRIPTION
On some platform, like GCP or OVMF which does NOT provide
EFI_GRAPHICS_OUTPUT_PROTOCOL when no display device (or the display device
be disabled). It causes that the "Error: Locate graphic output protocol
fail: (0xE) Not Found." always be showed on console when we enroll MOK
through MokManager. The message box blocked the process of enrolling
MOK and scared user. The error message is introduced by 55163bc82c517 since
15.2. This patch removed the error message.

https://github.com/rhboot/shim/issues/440