### PR TITLE
fallback: Add build flag to always try to chain-load the new boot entry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,10 @@ ifneq ($(origin FALLBACK_NONINTERACTIVE), undefined)
 	CFLAGS += -DFALLBACK_NONINTERACTIVE
 endif
 
+ifneq ($(origin FALLBACK_NEVER_REBOOT), undefined)
+	CFLAGS += -DFALLBACK_NEVER_REBOOT
+endif
+
 ifneq ($(origin FALLBACK_VERBOSE_WAIT), undefined)
 	CFLAGS += -DFALLBACK_VERBOSE_WAIT=$(FALLBACK_VERBOSE_WAIT)
 endif

--- a/fallback.c
+++ b/fallback.c
@@ -1059,6 +1059,9 @@ try_start_first_option(EFI_HANDLE parent_image_handle)
 static UINT32
 get_fallback_no_reboot(void)
 {
+#ifdef FALLBACK_NEVER_REBOOT
+	return 1;
+#else
 	EFI_STATUS efi_status;
 	UINT32 no_reboot;
 	UINTN size = sizeof(UINT32);
@@ -1069,6 +1072,7 @@ get_fallback_no_reboot(void)
 		return no_reboot;
 	}
 	return 0;
+#endif
 }
 
 #ifndef FALLBACK_NONINTERACTIVE
@@ -1184,7 +1188,13 @@ efi_main(EFI_HANDLE image, EFI_SYSTEM_TABLE *systab)
 		try_start_first_option(image);
 	} else {
 		if (get_fallback_no_reboot() == 1) {
-			VerbosePrint(L"NO_REBOOT is set, starting the first image\n");
+#ifdef FALLBACK_NEVER_REBOOT
+			const CHAR16 *reason = L"FALLBACK_NEVER_REBOOT";
+#else
+			const CHAR16 *reason = L"NO_REBOOT";
+#endif
+			VerbosePrint(L"%s is set, starting the first image\n",
+				     reason);
 			try_start_first_option(image);
 		}
 


### PR DESCRIPTION
The firmware on some Acer machines (and maybe others) always resets the
boot entries and BootOrder variable to what was defined in the firmware
setup program, overriding any external changes (including the changes
made by fallback).

Before shim cared about TPMs this was not a problem in practice, as
fallback would create and chain-load a boot entry for the OS on every
boot. However, since commit 431b8a2e75 the system is restarted if a TPM
is detected on the system, triggering an infinite reboot loop in systems
with such firmware. This is a known problem which has been previously
reported on https://github.com/rhboot/shim/issues/128

More recently, the problem has been addressed by commit a5db51a52e,
which presents a screen with a countdown to the user, where they can
interrupt boot and choose to have fallback always chain-load the new
entry instead of restarting the system, to break out of the reboot loop.
While this solution works, it has a few shortcomings:

 1. It makes an otherwise glitch-free boot process not smooth anymore.
 2. The message presented is not accessible / potentially scary for
    non-technical users: if they press a key to interrupt the boot
    process, the meaning of each option is not really clear for users
    not familiar with how shim and fallback work.
 3. The whole experience is made a bit worse by the fact that after
    selecting "Continue boot" / "Always continue boot", the screen will
    remain frozen until something else draw on the framebuffer. If GRUB
    is configured to be quiet, for a glitch-free boot, this may last
    several seconds until the kernel has started and loaded the
    manufacturer logo from BGRT, which gives the impression that the
    whole boot process froze.
 4. This Boot Option Restoration screen overwrites all the debug
    information printed before it is displayed, essentially neutering
    FALLBACK_VERBOSE or SHIM_VERBOSE and making it impossible to enable
    debug without rebuilding fallback.

This commit adds a build-time flag that forces fallback to always try to
chain-load the newly created boot entry, in the same way it did before
TPM support was added.

Fixes: https://github.com/rhboot/shim/issues/418

Signed-off-by: João Paulo Rechi Vita <jprvita@endlessos.org>