### PR TITLE
Allow MokListTrusted to be enabled by default

### DIFF
--- a/MokManager.c
+++ b/MokManager.c
@@ -1776,17 +1776,7 @@ static EFI_STATUS mok_tml_prompt(void *MokTML, UINTN MokTMLSize)
 		LibDeleteVariable(L"MokListTrustedNew", &SHIM_LOCK_GUID);
 		return EFI_ABORTED;
 	}
-
 	if (var->MokTMLState == 0) {
-		efi_status = RT->SetVariable(L"MokListTrusted", &SHIM_LOCK_GUID,
-					      EFI_VARIABLE_NON_VOLATILE |
-					      EFI_VARIABLE_BOOTSERVICE_ACCESS,
-					      1, &dbval);
-		if (EFI_ERROR(efi_status)) {
-			console_notify(L"Failed to set MokListTrusted state");
-			return efi_status;
-		}
-	} else {
 		efi_status = RT->SetVariable(L"MokListTrusted", &SHIM_LOCK_GUID,
 					      EFI_VARIABLE_NON_VOLATILE |
 					      EFI_VARIABLE_BOOTSERVICE_ACCESS,
@@ -1795,8 +1785,16 @@ static EFI_STATUS mok_tml_prompt(void *MokTML, UINTN MokTMLSize)
 			console_notify(L"Failed to delete MokListTrusted state");
 			return efi_status;
 		}
+	} else {
+		efi_status = RT->SetVariable(L"MokListTrusted", &SHIM_LOCK_GUID,
+					      EFI_VARIABLE_NON_VOLATILE |
+					      EFI_VARIABLE_BOOTSERVICE_ACCESS,
+					      1, &dbval);
+		if (EFI_ERROR(efi_status)) {
+			console_notify(L"Failed to set MokListTrusted state");
+			return efi_status;
+		}
 	}
-
 	return EFI_SUCCESS;
 }
 

--- a/include/test-data-efivars-1.h
+++ b/include/test-data-efivars-1.h
@@ -102,5 +102,9 @@ static const unsigned char test_data_efivars_1_SbatLevelRT[] = {
 	0x32, 0x31, 0x30, 0x33, 0x30, 0x32, 0x31, 0x38, 0x0a
 };
 
+static const unsigned char test_data_efivars_1_MokListTrustedRT[] ={
+	0x01
+};
+
 #endif /* !TEST_DATA_EFIVARS_1_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/test-mok-mirror.c
+++ b/test-mok-mirror.c
@@ -184,6 +184,10 @@ test_mok_mirror_0(void)
 		 .data_size = sizeof(test_data_efivars_1_SbatLevelRT),
 		 .data = test_data_efivars_1_SbatLevelRT
 		},
+		{.name = "MokListTrustedRT",
+		 .data_size = sizeof(test_data_efivars_1_MokListTrustedRT),
+		 .data = test_data_efivars_1_MokListTrustedRT
+		},
 		{.name = { 0, },
 		 .data_size = 0,
 		 .data = NULL,


### PR DESCRIPTION
Within previous versions of shim the MokListTrusted var did not
exist.  Add the ability through a compile time option to set
the MokListTrustedRT when the BS var does not exist.  When
the BS var exists, MokListTrustedRT is not set.  This inverse
logic allows a distro to give the end-user the ability to opt
out of this feature instead of opting in.

Many Linux distros carry out of tree patches to trust the mok
keys by default.  These out of tree patches can be dropped
when compiling shim this way and using a Linux kernel that
supports MokListTrustedRT.

Signed-off-by: Eric Snowberg <eric.snowberg@oracle.com>