### PR TITLE
vendor_cert: moving vendor_authorized and vendor_deauthorized back to…

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -6,12 +6,6 @@
 
 #include "shim.h"
 
-UINT32 vendor_authorized_size = 0;
-UINT8 *vendor_authorized = NULL;
-
-UINT32 vendor_deauthorized_size = 0;
-UINT8 *vendor_deauthorized = NULL;
-
 #if defined(ENABLE_SHIM_CERT)
 UINT32 build_cert_size;
 UINT8 *build_cert;

--- a/shim.c
+++ b/shim.c
@@ -33,6 +33,12 @@
 
 #include <stdint.h>
 
+UINT32 vendor_authorized_size = 0;
+UINT8 *vendor_authorized = NULL;
+
+UINT32 vendor_deauthorized_size = 0;
+UINT8 *vendor_deauthorized = NULL;
+
 #define OID_EKU_MODSIGN "1.3.6.1.4.1.2312.16.1.2"
 
 static EFI_SYSTEM_TABLE *systab;


### PR DESCRIPTION
… shim.c

for fixing building issue.

I got the following error when building shim 15.5 with VENDOR_CERT_FILE and
VENDOR_DBX_FILE:

[   58s] ld -o shim.so --hash-style=sysv -nostdlib -znocombreloc -T /home/abuild/rpmbuild/BUILD/shim-15.4/elf_aarch64_efi.lds -shared -Bsymbolic -Lgnu-efi/aarch64/gnuefi -Lgnu-efi/aarch64/lib -LCryptlib -LCryptl
[   58s] ld: shim.o: in function `check_denylist':
[   58s] /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:285: undefined reference to `vendor_dbx'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:287: undefined reference to `vendor_dbx_size'
[   58s] ld: shim.o: in function `verify_one_signature':
[   58s] /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:526: undefined reference to `vendor_cert_size'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:529: undefined reference to `vendor_cert_size'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:530: undefined reference to `vendor_cert'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:536: undefined reference to `vendor_cert'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:536: undefined reference to `vendor_cert_size'
[   58s] ld: shim.o: in function `shim_init':
[   58s] /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:1286: undefined reference to `vendor_cert_size'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:1286: undefined reference to `vendor_dbx_size'
[   58s] ld: shim.o: in function `efi_main':
[   58s] /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:1424: undefined reference to `vendor_cert_size'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:1425: undefined reference to `vendor_cert'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:1427: undefined reference to `vendor_dbx_size'
[   58s] ld: /home/abuild/rpmbuild/BUILD/shim-15.4/shim.c:1428: undefined reference to `vendor_dbx'
[   58s] ld: mok.o:(.data.rel+0x48): undefined reference to `vendor_cert'
[   58s] ld: mok.o:(.data.rel+0x50): undefined reference to `vendor_cert_size'
[   58s] ld: mok.o:(.data.rel+0xc8): undefined reference to `vendor_dbx'
[   58s] ld: mok.o:(.data.rel+0xd0): undefined reference to `vendor_dbx_size'
[   58s] make: *** [Makefile:140: shim.so] Error 1

The building command is here in my spec file for reference:

make RELEASE=0 SHIMSTEM=shim \
     VENDOR_CERT_FILE=shim-$suffix.der ENABLE_HTTPBOOT=1 \
     DEFAULT_LOADER="\\\\\\\\grub.efi" \
     VENDOR_DBX_FILE=$vendor_dbx \
     shim.efi.debug shim.efi

This patch moved the vendor_authorized and vendor_deauthorized and their
size variables back to shim.c for fixing the building issue.