### PR TITLE
tests: fix gcc warnings

### DIFF
--- a/mock-variables.c
+++ b/mock-variables.c
@@ -445,7 +445,7 @@ free_var(struct mock_variable *var)
 static bool
 mock_sv_attrs_match(UINT32 old, UINT32 new)
 {
-	UINT32 mask = ~EFI_VARIABLE_APPEND_WRITE;
+	UINT32 mask = ~((UINT32)EFI_VARIABLE_APPEND_WRITE);
 
 	return (old & mask) == (new & mask);
 }

--- a/test-str.c
+++ b/test-str.c
@@ -926,12 +926,15 @@ static int
 test_strncpy(void)
 {
 	char s[] = "0123456789abcdef\0000";
-	char s0[4096+4096];
-	char *s1 = &s0[4096];
+	char s0[4096];
+	char s1[4096];
 
 	memset(s0, 0, sizeof(s0));
 	memcpy(s0, s, sizeof(s));
-
+#if __GNUC_PREREQ(8, 1)
+# pragma GCC diagnostic push
+# pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
 	memset(s1, 0, 4096);
 	assert_equal_return(strncpy(s1, s0, 0), s1, -1, "got %p expected %p\n");
 	assert_equal_return(strlen(s1), 0, -1, "got %d expected %d\n");
@@ -1030,7 +1033,9 @@ test_strncpy(void)
 	assert_equal_return(s1[16], '\000', -1, "got %#02hhx expected %02hhx\n");
 	assert_equal_return(s1[17], '0', -1, "got %#02hhx expected %02hhx\n");
 	assert_equal_return(s1[18], '1', -1, "got %#02hhx expected %02hhx\n");
-
+#if __GNUC_PREREQ(8, 1)
+# pragma GCC diagnostic pop
+#endif
 	return 0;
 }
 
@@ -1038,12 +1043,12 @@ static int
 test_strcat(void)
 {
 	char s[] = "0123456789abcdef\0000";
-	char s0[8192];
-	char *s1 = &s0[4096];
+	char s0[4096];
+	char s1[4096];
 	char *s2;
 	char s3[] = "0123456789abcdef0123456789abcdef\000\000\000\000\000";
 
-	memset(s0, 0, 8192);
+	memset(s0, 0, sizeof(s0));
 	memcpy(s0, s, sizeof(s));
 
 	memset(s1, 0, 4096);


### PR DESCRIPTION
This PR fixes gcc warnings found when building the tests (also if FORTIFY_SOURCE enabled by default).

All tests passed with these changes.