### PR TITLE
tests: also look for system headers in multi-arch directories

### DIFF
--- a/include/test.mk
+++ b/include/test.mk
@@ -50,6 +50,9 @@ CFLAGS = $(OPTIMIZATIONS) -std=gnu11 \
 # of the "include" directory
 CFLAGS += -isystem $(shell $(CC) $(ARCH_CFLAGS) -print-file-name=include-fixed)
 
+# And on Debian also check the multi-arch include path
+CFLAGS += -isystem /usr/include/$(shell $(CC) $(ARCH_CFLAGS) -print-multiarch)
+
 export CFLAGS_LTO CFLAGS_GCOV
 
 libefi-test.a :


### PR DESCRIPTION
On Debian(-derived) systems low-level system headers are under
/usr/include/<multi-arch path>, so look there too.

Otherwise we see stuff like:

gcc -O2 -fno-diagnostics-color -ggdb -std=gnu11 -isystem <foo>/shim.git/include/system -I<foo>/shim.git/gnu-efi/inc -I<foo>/shim.git/gnu-efi/inc/ia32 -I<foo>/shim.git/gnu-efi/inc/protocol -Iinclude -iquote . -isystem /usr/include -isystem /usr/lib/gcc/i686-linux-gnu/11/include -mno-mmx -mno-sse -mno-red-zone -nostdinc -maccumulate-outgoing-args  -m32 -DMDE_CPU_IA32 -DPAGE_SIZE=4096   -fshort-wchar -fno-builtin -rdynamic -fno-inline -fno-eliminate-unused-debug-types -fno-eliminate-unused-debug-symbols -gpubnames -grecord-gcc-switches  -Wall -Wextra -Wno-missing-field-initializers -Wsign-compare -Wno-deprecated-declarations -Wno-unused-but-set-variable -Wno-unused-variable -Wno-pointer-sign -Werror -Werror=nonnull -Werror=nonnull-compare  -DEFI_FUNCTION_WRAPPER -DGNU_EFI_USE_MS_ABI -DPAGE_SIZE=4096 -DSHIM_UNIT_TEST -DDEFAULT_DEBUG_PRINT_STATE=0 -isystem include-fixed -o test-csv csv.c test-csv.c test.c libefi-test.a -lefivar
In file included from /usr/include/bits/errno.h:26,
                 from /usr/include/errno.h:28,
                 from /usr/include/efivar/efivar.h:24,
                 from include/test.h:51,
                 from shim.h:68,
                 from csv.c:6:
/usr/include/linux/errno.h:1:10: fatal error: asm/errno.h: No such file or directory
    1 | #include <asm/errno.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
In file included from /usr/include/bits/errno.h:26,
                 from /usr/include/errno.h:28,
                 from /usr/include/efivar/efivar.h:24,
                 from include/test.h:51,
                 from shim.h:68,
                 from test-csv.c:9:
/usr/include/linux/errno.h:1:10: fatal error: asm/errno.h: No such file or directory
    1 | #include <asm/errno.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
In file included from /usr/include/bits/errno.h:26,
                 from /usr/include/errno.h:28,
                 from /usr/include/efivar/efivar.h:24,
                 from include/test.h:51,
                 from shim.h:68,
                 from test.c:7:
/usr/include/linux/errno.h:1:10: fatal error: asm/errno.h: No such file or directory
    1 | #include <asm/errno.h>
      |          ^~~~~~~~~~~~~
compilation terminated.