### PR TITLE
SBAT revocation management

### DIFF
--- a/include/sbat.h
+++ b/include/sbat.h
@@ -8,8 +8,31 @@
 
 #define SBAT_VAR_SIG "sbat,"
 #define SBAT_VAR_VERSION "1,"
-#define SBAT_VAR_DATE "2021030218"
-#define SBAT_VAR SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_DATE "\n"
+#define SBAT_VAR_ORIGINAL_DATE "2021030218"
+#define SBAT_VAR_ORIGINAL SBAT_VAR_SIG SBAT_VAR_VERSION \
+	SBAT_VAR_ORIGINAL_DATE "\n"
+
+#if defined(ENABLE_SHIM_DEVEL)
+#define SBAT_VAR_PREVIOUS_DATE "2022020101"
+#define SBAT_VAR_PREVIOUS_REVOCATIONS "component,2\n"
+#define SBAT_VAR_PREVIOUS SBAT_VAR_SIG SBAT_VAR_VERSION \
+	SBAT_VAR_PREVIOUS_DATE "\n" SBAT_VAR_PREVIOUS_REVOCATIONS
+
+#define SBAT_VAR_LATEST_DATE "2022050100"
+#define SBAT_VAR_LATEST_REVOCATIONS "component,2\nothercomponent,2\n"
+#define SBAT_VAR_LATEST SBAT_VAR_SIG SBAT_VAR_VERSION \
+	SBAT_VAR_LATEST_DATE "\n" SBAT_VAR_LATEST_REVOCATIONS
+#else /* !ENABLE_SHIM_DEVEL */
+#define SBAT_VAR_PREVIOUS_DATE SBAT_VAR_ORIGINAL_DATE
+#define SBAT_VAR_PREVIOUS_REVOCATIONS
+#define SBAT_VAR_PREVIOUS SBAT_VAR_SIG SBAT_VAR_VERSION \
+	SBAT_VAR_PREVIOUS_DATE "\n" SBAT_VAR_PREVIOUS_REVOCATIONS
+
+#define SBAT_VAR_LATEST_DATE SBAT_VAR_ORIGINAL_DATE
+#define SBAT_VAR_LATEST_REVOCATIONS
+#define SBAT_VAR_LATEST SBAT_VAR_SIG SBAT_VAR_VERSION \
+	SBAT_VAR_LATEST_DATE "\n" SBAT_VAR_LATEST_REVOCATIONS
+#endif /* ENABLE_SHIM_DEVEL */
 
 #define UEFI_VAR_NV_BS \
 	(EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS)
@@ -33,6 +56,9 @@
 #define SBAT_VAR_ATTRS UEFI_VAR_NV_BS
 #endif
 
+#define SBAT_POLICY L"SbatPolicy"
+#define SBAT_POLICY8 "SbatPolicy"
+
 extern UINTN _sbat, _esbat;
 
 struct sbat_var_entry {
@@ -51,7 +77,8 @@ extern list_t sbat_var;
 EFI_STATUS parse_sbat_var(list_t *entries);
 void cleanup_sbat_var(list_t *entries);
 EFI_STATUS set_sbat_uefi_variable(void);
-bool preserve_sbat_uefi_variable(UINT8 *sbat, UINTN sbatsize, UINT32 attributes);
+bool preserve_sbat_uefi_variable(UINT8 *sbat, UINTN sbatsize,
+				 UINT32 attributes, char *sbar_var);
 
 struct sbat_section_entry {
 	const CHAR8 *component_name;

--- a/test-sbat.c
+++ b/test-sbat.c
@@ -14,6 +14,11 @@
 
 list_t sbat_var;
 
+BOOLEAN
+secure_mode() {
+	return 1;
+}
+
 #if 0
 /*
  * Mock test helpers
@@ -965,11 +970,39 @@ err:
 int
 test_preserve_sbat_uefi_variable_good(void)
 {
-	char sbat[] = "sbat,1,\ncomponent,2,\n";
+	char sbat[] = "sbat,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2021030218\n";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = SBAT_VAR_ATTRS;
 
-	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes))
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
+		return 0;
+	else
+		return -1;
+}
+
+int
+test_preserve_sbat_uefi_variable_newer(void)
+{
+	char sbat[] = "sbat,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2025030218\ncomponent,5,\n";
+	size_t sbat_size = sizeof(sbat);
+	UINT32 attributes = SBAT_VAR_ATTRS;
+
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
+		return -1;
+	else
+		return 0;
+}
+int
+test_preserve_sbat_uefi_variable_older(void)
+{
+	char sbat[] = "sbat,1,2025030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2020030218\ncomponent,1,\n";
+	size_t sbat_size = sizeof(sbat);
+	UINT32 attributes = SBAT_VAR_ATTRS;
+
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
 		return 0;
 	else
 		return -1;
@@ -978,11 +1011,12 @@ test_preserve_sbat_uefi_variable_good(void)
 int
 test_preserve_sbat_uefi_variable_bad_sig(void)
 {
-	char sbat[] = "bad_sig,1,\ncomponent,2,\n";
+	char sbat[] = "bad_sig,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2021030218\n";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = SBAT_VAR_ATTRS;
 
-	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes))
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
 		return -1;
 	else
 		return 0;
@@ -991,11 +1025,12 @@ test_preserve_sbat_uefi_variable_bad_sig(void)
 int
 test_preserve_sbat_uefi_variable_bad_attr(void)
 {
-	char sbat[] = "sbat,1,\ncomponent,2,\n";
+	char sbat[] = "sbat,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2021030218\n";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = 0;
 
-	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes))
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
 		return -1;
 	else
 		return 0;
@@ -1005,10 +1040,11 @@ int
 test_preserve_sbat_uefi_variable_bad_short(void)
 {
 	char sbat[] = "sba";
+	char sbatvar[] = "sbat,1,2021030218\n";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = SBAT_VAR_ATTRS;
 
-	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes))
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
 		return -1;
 	else
 		return 0;
@@ -1052,6 +1088,8 @@ main(void)
 	test(test_parse_and_verify);
 
 	test(test_preserve_sbat_uefi_variable_good);
+	test(test_preserve_sbat_uefi_variable_newer);
+	test(test_preserve_sbat_uefi_variable_older);
 	test(test_preserve_sbat_uefi_variable_bad_sig);
 	test(test_preserve_sbat_uefi_variable_bad_attr);
 	test(test_preserve_sbat_uefi_variable_bad_short);


### PR DESCRIPTION
Support for updating SBAT revocations to latest or previous revocations.

Allow SBAT revocations to be reset to empty metada
only when UEFI Secure Boot is disabled.

Signed-off-by: Jan Setje-Eilers <Jan.SetjeEilers@oracle.com>