### PR TITLE
Re-add ARM AArch64 support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "gnu-efi"]
 	path = gnu-efi
 	url = https://github.com/rhboot/gnu-efi.git
-	branch = shim-15.5
+	branch = shim-15.6

--- a/Make.defaults
+++ b/Make.defaults
@@ -84,9 +84,7 @@ ifeq ($(ARCH),aarch64)
 	ARCH_GNUEFI		?= aarch64
 	ARCH_SUFFIX		?= aa64
 	ARCH_SUFFIX_UPPER	?= AA64
-	FORMAT			:= -O binary
-	SUBSYSTEM		:= 0xa
-	ARCH_LDFLAGS		+= --defsym=EFI_SUBSYSTEM=$(SUBSYSTEM)
+	ARCH_LDFLAGS		?=
 	ARCH_CFLAGS		?=
 endif
 ifeq ($(ARCH),arm)

--- a/elf_aarch64_efi.lds
+++ b/elf_aarch64_efi.lds
@@ -3,109 +3,94 @@ OUTPUT_ARCH(aarch64)
 ENTRY(_start)
 SECTIONS
 {
-  .text 0x0 : {
-    _text = .;
-    *(.text.head)
-    *(.text)
-    *(.text.*)
-    *(.gnu.linkonce.t.*)
-    _evtext = .;
-    . = ALIGN(4096);
+  . = 0;
+  ImageBase = .;
+  .hash : { *(.hash) }	/* this MUST come first! */
+  . = ALIGN(4096);
+  .eh_frame :
+  {
+    *(.eh_frame)
   }
-  _etext = .;
-  _text_size = . - _text;
-  _text_vsize = _evtext - _text;
+  . = ALIGN(4096);
+  .text :
+  {
+   _text = .;
+   *(.text)
+   *(.text.*)
+   *(.gnu.linkonce.t.*)
+   _etext = .;
+  }
+  . = ALIGN(4096);
+  .reloc :
+  {
+   *(.reloc)
+  }
+  . = ALIGN(4096);
+  .note.gnu.build-id : {
+    *(.note.gnu.build-id)
+  }
+
+  . = ALIGN(4096);
+  .data.ident : {
+    *(.data.ident)
+  }
 
   . = ALIGN(4096);
   .data :
   {
    _data = .;
-   *(.sdata)
-   *(.data)
-   *(.data1)
-   *(.data.*)
+   *(.rodata*)
    *(.got.plt)
    *(.got)
-
-   *(.dynamic)
-
+   *(.data*)
+   *(.sdata)
    /* the EFI loader doesn't seem to like a .bss section, so we stick
       it all into .data: */
-   . = ALIGN(16);
-   _bss = .;
    *(.sbss)
    *(.scommon)
    *(.dynbss)
    *(.bss)
    *(COMMON)
-   _evdata = .;
-   . = ALIGN(4096);
-   _bss_end = .;
+   *(.rel.local)
+  }
+
+  . = ALIGN(4096);
+  .vendor_cert :
+  {
+   *(.vendor_cert)
+  }
+  . = ALIGN(4096);
+  .dynamic  : { *(.dynamic) }
+  . = ALIGN(4096);
+  .rela :
+  {
+    *(.rela.data*)
+    *(.rela.got*)
+    *(.rela.stab*)
   }
   _edata = .;
-  _data_vsize = _evdata - _data;
   _data_size = . - _data;
-
-  /*
-   * Note that _sbat must be the beginning of the data, and _esbat must be the
-   * end and must be before any section padding.  The sbat self-check uses
-   * _esbat to find the bounds of the data, and if the padding is included, the
-   * CSV parser (correctly) rejects the data as having NUL values in one of the
-   * required columns.
-   */
   . = ALIGN(4096);
   .sbat :
   {
     _sbat = .;
     *(.sbat)
     *(.sbat.*)
-    _esbat = .;
-    . = ALIGN(4096);
-    _epsbat = .;
   }
-  _sbat_size = _epsbat - _sbat;
-  _sbat_vsize = _esbat - _sbat;
+  _esbat = .;
+  _sbat_size = . - _sbat;
 
   . = ALIGN(4096);
-  .rodata :
-  {
-    _rodata = .;
-    *(.rodata*)
-    *(.srodata)
-    . = ALIGN(16);
-    *(.note.gnu.build-id)
-    . = ALIGN(4096);
-    *(.vendor_cert)
-    *(.data.ident)
-    . = ALIGN(4096);
-  }
+  .dynsym   : { *(.dynsym) }
   . = ALIGN(4096);
-  .rela :
-  {
-    *(.rela.dyn)
-    *(.rela.plt)
-    *(.rela.got)
-    *(.rela.data)
-    *(.rela.data*)
-  }
+  .dynstr   : { *(.dynstr) }
   . = ALIGN(4096);
-  .dyn :
+  .ignored.reloc :
   {
-    *(.dynsym)
-    *(.dynstr)
-    _evrodata = .;
-    . = ALIGN(4096);
-  }
-  _erodata = .;
-  _rodata_size = . - _rodata;
-  _rodata_vsize = _evrodata - _rodata;
-  _alldata_size = . - _data;
-
-  /DISCARD/ :
-  {
-    *(.rel.reloc)
+    *(.rela.reloc)
     *(.eh_frame)
     *(.note.GNU-stack)
   }
   .comment 0 : { *(.comment) }
+  .note.gnu.build-id : { *(.note.gnu.build-id) }
 }


### PR DESCRIPTION
This patchset resurrects aarch64 support, using new objcopy options that are in binutils-2.38.  Note that the gnu-efi branch changes, and the shim-15.6 branch has several patches on it.