### PR TITLE
Fix github PR hook built test failures on Fedora 36

### DIFF
--- a/include/test.h
+++ b/include/test.h
@@ -50,6 +50,10 @@
 
 #include <efivar/efivar.h>
 
+/* workaround for incompatible efivar-devel definitions */
+#undef EFI_VARIABLE_APPEND_WRITE
+#include "efiauthenticated.h"
+
 #include <assert.h>
 
 #include "list.h"


### PR DESCRIPTION
This may or may not be appropriate.

If the variable types can be resolved in the more recent efivar-devel, then the first patch should not be merged. The ull literals
should likely gain new names.
