### PR TITLE
shim: use SHIM_DEVEL_VERBOSE when built in devel mode

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -35,7 +35,8 @@ Variables you could set to customize the build:
   If this is set, we look for SHIM_DEVEL_DEBUG instead of SHIM_DEBUG in
   our debugger delay hook, thus meaning you can have it pause for a
   debugger only on the development branch and not the OS you need to boot
-  to scp in a new development build.
+  to scp in a new development build.  Likewise, we look for
+  SHIM_DEVEL_VERBOSE rather than SHIM_VERBOSE.
 - DISABLE_EBS_PROTECTION
   On systems where a second stage bootloader is not used, and the Linux
   Kernel is embedded in the same EFI image as shim and booted directly

--- a/fallback.c
+++ b/fallback.c
@@ -24,7 +24,7 @@ get_fallback_verbose(void)
 	if (state != -1)
 		return state;
 
-	efi_status = get_variable(L"FALLBACK_VERBOSE",
+	efi_status = get_variable(FALLBACK_VERBOSE_VAR_NAME,
 				  &data, &dataSize, SHIM_LOCK_GUID);
 	if (EFI_ERROR(efi_status)) {
 		state = 0;
@@ -1130,7 +1130,7 @@ debug_hook(void)
 	register volatile int x = 0;
 	extern char _etext, _edata;
 
-	efi_status = get_variable(L"SHIM_DEBUG", &data, &dataSize,
+	efi_status = get_variable(DEBUG_VAR_NAME, &data, &dataSize,
 				  SHIM_LOCK_GUID);
 	if (EFI_ERROR(efi_status)) {
 		return;

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -41,6 +41,10 @@ CFLAGS		= $(FEATUREFLAGS) \
 		  $(INCLUDES) \
 		  $(DEFINES)
 
+ifneq ($(origin ENABLE_SHIM_DEVEL),undefined)
+CFLAGS += -DENABLE_SHIM_DEVEL
+endif
+
 lib.a: $(LIBFILES)
 	$(AR) rcs lib.a $(LIBFILES)
 

--- a/lib/console.c
+++ b/lib/console.c
@@ -732,7 +732,7 @@ setup_verbosity(VOID)
 	UINTN verbose_check_size;
 
 	verbose_check_size = sizeof(verbose);
-	efi_status = get_variable(L"SHIM_VERBOSE", &verbose_check_ptr,
+	efi_status = get_variable(VERBOSE_VAR_NAME, &verbose_check_ptr,
 				  &verbose_check_size, SHIM_LOCK_GUID);
 	if (!EFI_ERROR(efi_status)) {
 		verbose = *(__typeof__(verbose) *)verbose_check_ptr;

--- a/shim.c
+++ b/shim.c
@@ -1450,17 +1450,10 @@ debug_hook(void)
 	register volatile UINTN x = 0;
 	extern char _text, _data;
 
-	const CHAR16 * const debug_var_name =
-#ifdef ENABLE_SHIM_DEVEL
-		L"SHIM_DEVEL_DEBUG";
-#else
-		L"SHIM_DEBUG";
-#endif
-
 	if (x)
 		return;
 
-	efi_status = get_variable(debug_var_name, &data, &dataSize,
+	efi_status = get_variable(DEBUG_VAR_NAME, &data, &dataSize,
 				  SHIM_LOCK_GUID);
 	if (EFI_ERROR(efi_status)) {
 		return;
@@ -1474,7 +1467,7 @@ debug_hook(void)
 
 	console_print(L"Pausing for debugger attachment.\n");
 	console_print(L"To disable this, remove the EFI variable %s-%g .\n",
-		      debug_var_name, &SHIM_LOCK_GUID);
+		      DEBUG_VAR_NAME, &SHIM_LOCK_GUID);
 	x = 1;
 	while (x++) {
 		/* Make this so it can't /totally/ DoS us. */

--- a/shim.h
+++ b/shim.h
@@ -284,6 +284,16 @@ verify_buffer (char *data, int datasize,
 #define LogError(fmt, ...)
 #endif
 
+#ifdef ENABLE_SHIM_DEVEL
+#define FALLBACK_VERBOSE_VAR_NAME L"FALLBACK_DEVEL_VERBOSE"
+#define VERBOSE_VAR_NAME L"SHIM_DEVEL_VERBOSE"
+#define DEBUG_VAR_NAME L"SHIM_DEVEL_DEBUG"
+#else
+#define FALLBACK_VERBOSE_VAR_NAME L"FALLBACK_VERBOSE"
+#define VERBOSE_VAR_NAME L"SHIM_VERBOSE"
+#define DEBUG_VAR_NAME L"SHIM_DEBUG"
+#endif
+
 char *translate_slashes(char *out, const char *str);
 
 #endif /* SHIM_H_ */


### PR DESCRIPTION
This makes SHIM_VERBOSE / SHIM_DEVEL_VERBOSE work the same way as
SHIM_DEBUG / SHIM_DEVEL_DEBUG when shim is built with ENABLE_SHIM_DEVEL
set.

Signed-off-by: Peter Jones <pjones@redhat.com>