### PR TITLE
Fix preserve_sbat_uefi_variable() logic

### DIFF
--- a/test-sbat.c
+++ b/test-sbat.c
@@ -970,8 +970,8 @@ err:
 int
 test_preserve_sbat_uefi_variable_good(void)
 {
-	char sbat[] = "sbat,1,2021030218\ncomponent,2,\n";
-	char sbatvar[] = "sbat,1,2021030218\n";
+	char sbat[] =    "sbat,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2021030218\ncomponent,2,\n";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = SBAT_VAR_ATTRS;
 
@@ -982,10 +982,67 @@ test_preserve_sbat_uefi_variable_good(void)
 }
 
 int
+test_preserve_sbat_uefi_variable_version_newer(void)
+{
+	char sbat[] =    "sbat,2,2022030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2021030218\ncomponent,2,\n";
+	size_t sbat_size = sizeof(sbat);
+	UINT32 attributes = SBAT_VAR_ATTRS;
+
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
+		return 0;
+	else
+		return -1;
+}
+
+int
+test_preserve_sbat_uefi_variable_version_newerlonger(void)
+{
+	char sbat[] =    "sbat,10,2022030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,2,2021030218\ncomponent,2,\n";
+	size_t sbat_size = sizeof(sbat);
+	UINT32 attributes = SBAT_VAR_ATTRS;
+
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
+		return 0;
+	else
+		return -1;
+}
+
+int
+test_preserve_sbat_uefi_variable_version_older(void)
+{
+	char sbat[] =    "sbat,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,2,2022030218\ncomponent,2,\n";
+	size_t sbat_size = sizeof(sbat);
+	UINT32 attributes = SBAT_VAR_ATTRS;
+
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
+		return -1;
+	else
+		return 0;
+}
+
+int
+test_preserve_sbat_uefi_variable_version_olderlonger(void)
+{
+	char sbat[] =    "sbat,2,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,10,2022030218\ncomponent,2,\n";
+	size_t sbat_size = sizeof(sbat);
+	UINT32 attributes = SBAT_VAR_ATTRS;
+
+	if (preserve_sbat_uefi_variable(sbat, sbat_size, attributes, sbatvar))
+		return -1;
+	else
+		return 0;
+}
+
+
+int
 test_preserve_sbat_uefi_variable_newer(void)
 {
-	char sbat[] = "sbat,1,2021030218\ncomponent,2,\n";
-	char sbatvar[] = "sbat,1,2025030218\ncomponent,5,\n";
+	char sbat[] =    "sbat,1,2021030218\ncomponent,2,\n";
+	char sbatvar[] = "sbat,1,2025030218\ncomponent,5,\ncomponent,3";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = SBAT_VAR_ATTRS;
 
@@ -997,7 +1054,7 @@ test_preserve_sbat_uefi_variable_newer(void)
 int
 test_preserve_sbat_uefi_variable_older(void)
 {
-	char sbat[] = "sbat,1,2025030218\ncomponent,2,\n";
+	char sbat[] =    "sbat,1,2025030218\ncomponent,2,\ncomponent,3";
 	char sbatvar[] = "sbat,1,2020030218\ncomponent,1,\n";
 	size_t sbat_size = sizeof(sbat);
 	UINT32 attributes = SBAT_VAR_ATTRS;
@@ -1093,6 +1150,10 @@ main(void)
 	test(test_preserve_sbat_uefi_variable_bad_sig);
 	test(test_preserve_sbat_uefi_variable_bad_attr);
 	test(test_preserve_sbat_uefi_variable_bad_short);
+	test(test_preserve_sbat_uefi_variable_version_newer);
+	test(test_preserve_sbat_uefi_variable_version_newerlonger);
+	test(test_preserve_sbat_uefi_variable_version_older);
+	test(test_preserve_sbat_uefi_variable_version_olderlonger);
 
 	return 0;
 }


### PR DESCRIPTION
preserve_sbat_uefi_variable() shoud really deal with the sbat
metadata version as a numerical value that could gain more digits.

It also needs to only compare the datestamp since the actual
metadata can grow and shrink

Signed-off-by: Jan Setje-Eilers <Jan.SetjeEilers@oracle.com>