### PR TITLE
Add a link to the test plan in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,5 @@ pub.cer and build with `make VENDOR_CERT_FILE=pub.cer`.
 
 There are a couple of build options, and a couple of ways to customize the
 build, described in [BUILDING](BUILDING).
+
+See the [test plan](testplan.txt), and file a ticket if anything fails!


### PR DESCRIPTION
It's been suggested that we should link to the test plan in the readme.
This seems pretty reasonable to me, so here it is.

Signed-off-by: Peter Jones <pjones@redhat.com>