### PR TITLE
free memory for variable - sbat_policy

### DIFF
--- a/sbat.c
+++ b/sbat.c
@@ -453,6 +453,7 @@ set_sbat_uefi_variable(void)
 				clear_sbat_policy();
 				break;
 		}
+		FreePool(sbat_policy);
 	}
 
 	efi_status = get_variable_attr(SBAT_VAR_NAME, &sbat, &sbatsize,


### PR DESCRIPTION
The caller should take the responsibility to free memory got from get_variable_attr( ) for the variable sbat_policy.