### PR TITLE
free memory of sbat_policy

### DIFF
--- a/sbat.c
+++ b/sbat.c
@@ -453,6 +453,7 @@ set_sbat_uefi_variable(void)
 				clear_sbat_policy();
 				break;
 		}
+		FreePool(sbat_policy);
 	}
 
 	efi_status = get_variable_attr(SBAT_VAR_NAME, &sbat, &sbatsize,


### PR DESCRIPTION
Signed-off-by: Dennis Tseng <dennis.tseng@suse.com>

When calling get_variable_attr( ), the called should take the responsibility for memory release.