### PR TITLE
shim: Flush the memory region from i-cache before execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ TARGETS += $(MMNAME) $(FBNAME)
 endif
 OBJS	= shim.o globals.o mok.o netboot.o cert.o replacements.o tpm.o version.o errlog.o sbat.o sbat_data.o sbat_var.o pe.o httpboot.o csv.o load-options.o
 KEYS	= shim_cert.h ocsp.* ca.* shim.crt shim.csr shim.p12 shim.pem shim.key shim.cer
-ORIG_SOURCES	= shim.c globals.c mok.c netboot.c replacements.c tpm.c errlog.c sbat.c pe.c httpboot.c shim.h version.h $(wildcard include/*.h) cert.S sbat_var.S
+ORIG_SOURCES	= shim.c globals.c mok.c netboot.c replacements.c tpm.c errlog.c sbat.c pe.c httpboot.c shim.h version.h cache.h $(wildcard include/*.h) cert.S sbat_var.S
 MOK_OBJS = MokManager.o PasswordCrypt.o crypt_blowfish.o errlog.o sbat_data.o globals.o
 ORIG_MOK_SOURCES = MokManager.c PasswordCrypt.c crypt_blowfish.c shim.h $(wildcard include/*.h)
 FALLBACK_OBJS = fallback.o tpm.o errlog.o sbat_data.o globals.o

--- a/cache.h
+++ b/cache.h
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#ifndef CACHE_H_
+#define CACHE_H_
+
+#if defined(__GNUC__)
+#define cache_invalidate(begin, end)  __builtin___clear_cache(begin, end)
+#else /* __GNUC__ */
+#error shim has no cache_invalidate() implementation for this compiler
+#endif /* __GNUC__ */
+
+#endif /* CACHE_H_ */

--- a/pe.c
+++ b/pe.c
@@ -5,6 +5,7 @@
  */
 
 #include "shim.h"
+#include "cache.h"
 
 #include <openssl/err.h>
 #include <openssl/bn.h>
@@ -1195,6 +1196,9 @@ handle_image (void *data, unsigned int datasize,
 			 MEM_ATTR_X);
 
 	CopyMem(buffer, data, context.SizeOfHeaders);
+
+	/* Flush the instruction cache for the region holding the image */
+	cache_invalidate(buffer, buffer + context.ImageSize);
 
 	*entry_point = ImageAddress(buffer, context.ImageSize, context.EntryPoint);
 	if (!*entry_point) {


### PR DESCRIPTION
…ing it

We've seen crashes in early GRUB code on an ARM Cortex-A72-based platform
that point at seemingly harmless instructions. Flushing the i-cache of
those instructions prior to executing seems to work fine, which seems to
have parallels with this story:
  https://www.mail-archive.com/osv-dev@googlegroups.com/msg06203.html

Add a cache flushing utility function that is a no-op for !arm64, and
and provide an implementation using a GCC intrinsic.

This fixes issue #498.

Signed-off-by: dann frazier <dann.frazier@canonical.com>