### PR TITLE
Discard load-options that start with a NUL

### DIFF
--- a/include/ucs2.h
+++ b/include/ucs2.h
@@ -63,22 +63,4 @@ StrCSpn(const CHAR16 *s, const CHAR16 *reject)
 	return ret;
 }
 
-/*
- * Test if an entire buffer is nothing but NUL characters.  This
- * implementation "gracefully" ignores the difference between the
- * UTF-8/ASCII 1-byte NUL and the UCS-2 2-byte NUL.
- */
-static inline bool
-__attribute__((__unused__))
-is_all_nuls(UINT8 *data, UINTN data_size)
-{
-	UINTN i;
-
-	for (i = 0; i < data_size; i++) {
-		if (data[i] != 0)
-			return false;
-	}
-	return true;
-}
-
 #endif /* SHIM_UCS2_H */

--- a/load-options.c
+++ b/load-options.c
@@ -404,8 +404,13 @@ parse_load_options(EFI_LOADED_IMAGE *li)
 
 	/*
 	 * Apparently sometimes we get L"\0\0"?  Which isn't useful at all.
+	 *
+	 * Possibly related, but some boards have additional data before the
+	 * size which is garbage (it's a weird path to the directory
+	 * containing the loaders).  Known boards that do this: Kontron VX3040
+	 * (AMI), ASUS B85M-E, and at least one "older Dell laptop".
 	 */
-	if (is_all_nuls(li->LoadOptions, li->LoadOptionsSize))
+	if (((CHAR16 *)li->LoadOptions)[0] == 0)
 		return EFI_SUCCESS;
 
 	/*


### PR DESCRIPTION
In 6c8d08c0af4768c715b79c8ec25141d56e34f8b4 ("shim: Ignore UEFI
LoadOptions that are just NUL characters."), a check was added to
discard load options that are entirely NUL.  We now see some firmwares
that start LoadOptions with a NUL, and then follow it with garbage (path
to directory containing loaders).  Widen the check to just discard
anything that starts with a NUL.

Resolves: #490
Related: #95
See-also: https://bugzilla.redhat.com/show_bug.cgi?id=2113005
Signed-off-by: Robbie Harwood <rharwood@redhat.com>