### PR TITLE
Fix NULL pointer dereference in AuthenticodeVerify()

### DIFF
--- a/Cryptlib/Pk/CryptAuthenticode.c
+++ b/Cryptlib/Pk/CryptAuthenticode.c
@@ -106,7 +106,7 @@ AuthenticodeVerify (
   //
   // Check if it's PKCS#7 Signed Data (for Authenticode Scenario)
   //
-  if (!PKCS7_type_is_signed (Pkcs7)) {
+  if (!PKCS7_type_is_signed (Pkcs7) || PKCS7_get_detached (Pkcs7)) {
     goto _Exit;
   }
 


### PR DESCRIPTION
Thanks for the comments from @frozencemetery.
Add PKCS7_get_detached() checking to avoid parsing a NULL ASN.1 object related to the PKCS#7 signed data(d.sign->contents->d.ptr). 

This CVE-2019-14584 bug has been fixed in edk2 upstream. Please refer the fix from edk2 upstream:
https://bugzilla.tianocore.org/show_bug.cgi?id=1914 
https://edk2.groups.io/g/devel/message/66309

Signed-off-by: Gary Lin <glin@suse.com>
Signed-off-by: Dennis Tseng <dennis.tseng@suse.com>