### PR TITLE
Fix: Keep BOOT CSV be Unicode format file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,7 +178,7 @@ buildid : $(TOPDIR)/buildid.c
 
 $(BOOTCSVNAME) :
 	@echo Making $@
-	@echo "$(SHIMNAME),$(OSLABEL),,This is the boot entry for $(OSLABEL)" | iconv -t UCS-2LE > $@
+	@echo "$(SHIMNAME),$(OSLABEL),,This is the boot entry for $(OSLABEL)" | iconv -t unicode > $@
 
 install-check :
 ifeq ($(origin LIBDIR),undefined)


### PR DESCRIPTION
In CentOS and AlmaLinux, the CSV file:
```
00000000  ff fe 73 00 68 00 69 00  6d 00 69 00 61 00 33 00  |..s.h.i.m.i.a.3.| 
00000010  32 00 2e 00 65 00 66 00  69 00 2c 00 43 00 65 00  |2...e.f.i.,.C.e.|
```
It's unicode file marked by `'ff fe'` characters, however, `iconv -t UCS-2LE` not provided:
```
00000000  73 00 68 00 69 00 6d 00  61 00 61 00 36 00 34 00  |s.h.i.m.a.a.6.4.| 
00000010  2e 00 65 00 66 00 69 00  2c 00 41 00 6c 00 6d 00  |..e.f.i.,.A.l.m.|
```
