### PR TITLE
Disable exporting vendor-dbx to MokListXRT

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -118,8 +118,10 @@ struct mok_state_variable mok_state_variable_data[] = {
 		     EFI_VARIABLE_NON_VOLATILE,
 	 .no_attr = EFI_VARIABLE_RUNTIME_ACCESS,
 	 .categorize_addend = categorize_deauthorized,
+#ifndef DISABLE_EXPORT_DBX
 	 .addend = &vendor_deauthorized,
 	 .addend_size = &vendor_deauthorized_size,
+#endif
 	 .flags = MOK_MIRROR_KEYDB |
 		  MOK_MIRROR_DELETE_FIRST |
 		  MOK_VARIABLE_LOG,


### PR DESCRIPTION
As the vendor-dbx grows, it caused some problems when writing such a large variable. Some firmwares lie the avaiable space(*1) , and some even crash(*2) for no good reason after the writing of MokListXRT. Both shim and kernel don't rely on MokListXRT to block anything, so we just stop exporting vendor-dbx to MokListXRT to avoid the potential hassles.

(*1) https://bugzilla.suse.com/show_bug.cgi?id=1185261 
(*2) https://github.com/rhboot/shim/pull/369#issuecomment-855275115

Signed-off-by: Gary Lin <glin@suse.com>
Signed-off-by: Dennis Tseng <dennis.tseng@suse.com>