### PR TITLE
Add -malign-double to IA32 compiler flags

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -71,7 +71,7 @@ ifeq ($(ARCH),x86_64)
 endif
 ifeq ($(ARCH),ia32)
 	ARCH_CFLAGS		?= -mno-mmx -mno-sse -mno-red-zone -nostdinc \
-				   $(CLANG_BUGS) -m32 \
+				   $(CLANG_BUGS) -m32 -malign-double \
 				   -DMDE_CPU_IA32 -DPAGE_SIZE=4096
 	ARCH_GNUEFI		?= ia32
 	ARCH_SUFFIX		?= ia32


### PR DESCRIPTION
This changes the alignment of UINT64 data to 8 bytes on IA32, which matches EDK2's understanding of alignment. In particular this change affects the offset where shim writes `EFI_LOADED_IMAGE.ImageSize`.

Fixes https://github.com/rhboot/shim/issues/515

Signed-off-by: Nicholas Bishop <nicholasbishop@google.com>