### PR TITLE
pe: Fix image section entry-point validation

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -1259,7 +1259,7 @@ handle_image (void *data, unsigned int datasize,
 		}
 
 		if (Section->VirtualAddress <= context.EntryPoint &&
-		    (Section->VirtualAddress + Section->SizeOfRawData - 1)
+		    (Section->VirtualAddress + Section->Misc.VirtualSize - 1)
 		    > context.EntryPoint)
 			found_entry_point++;
 


### PR DESCRIPTION
Seen mokmanager image load failure '2 sections contain entry point' for shim built on Oracle Linux 9 aarch64. found_entry_point counter in handle_image() uses SizeOfRawData to calculate section boundary. PE spec defines VirtualSize for the total size of the section when loaded into memory. SizeOfRawData is the size of the section (for object files) or the size of the initialized data on disk.

Fix this issue by updating section in-memory size limit to VirtualSize.

Resolves: #517
Signed-off-by: Ilya Okomin <ilya.okomin@oracle.com>