### PR TITLE
mok: remove MokListTrusted from PCR 7

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -178,7 +178,6 @@ struct mok_state_variable mok_state_variable_data[] = {
 		     EFI_VARIABLE_NON_VOLATILE,
 	 .no_attr = EFI_VARIABLE_RUNTIME_ACCESS,
 	 .flags = MOK_MIRROR_DELETE_FIRST |
-		  MOK_VARIABLE_MEASURE |
 		  MOK_VARIABLE_INVERSE |
 		  MOK_VARIABLE_LOG,
 	 .pcr = 14,


### PR DESCRIPTION
MokListTrusted was added by mistake to PCR 7 in 4e513405. The value of MokListTrusted does not alter the behavior of secure boot so, as per https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_PFP_r1p05_v23_pub.pdf#page=36 (section 3.3.4 PCR usage) so it should not be factored in the value of PCR 7.

See:
  https://github.com/rhboot/shim/pull/423
  https://github.com/rhboot/shim/commit/4e513405b4f1641710115780d19dcec130c5208f

Fixes https://github.com/rhboot/shim/issues/484
Fixes https://github.com/rhboot/shim/issues/492