### PR TITLE
Make the names of EFI binaries arch-independent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ ifneq ($(origin FALLBACK_VERBOSE_WAIT), undefined)
 	CFLAGS += -DFALLBACK_VERBOSE_WAIT=$(FALLBACK_VERBOSE_WAIT)
 endif
 
+ifneq ($(origin ARCH_INDEPEND),undefined)
+	CFLAGS += -DARCH_INDEPEND
+endif
+
 all: confcheck $(TARGETS)
 
 confcheck:

--- a/fallback.c
+++ b/fallback.c
@@ -1143,7 +1143,11 @@ debug_hook(void)
 
 	x = 1;
 	console_print(L"add-symbol-file "DEBUGDIR
+#ifndef ARCH_INDEPEND	
 		      L"fb" EFI_ARCH L".efi.debug %p -s .data %p\n",
+#else	   
+            	      L"fallback.efi.debug %p -s .data %p\n",
+#endif		      
 		      &_etext, &_edata);
 }
 

--- a/shim.c
+++ b/shim.c
@@ -1597,7 +1597,11 @@ debug_hook(void)
 	FreePool(data);
 
 	console_print(L"add-symbol-file "DEBUGDIR
+#ifdef ARCH_INDEPEND
 		      L"shim" EFI_ARCH L".efi.debug 0x%08x -s .data 0x%08x\n",
+#else	      	      
+		      L"shim.efi.debug 0x%08x -s .data 0x%08x\n",
+#endif		      
 		      &_text, &_data);
 
 	console_print(L"Pausing for debugger attachment.\n");

--- a/shim.h
+++ b/shim.h
@@ -132,8 +132,13 @@
 #define DEBUGSRC L"/usr/src/debug/shim-" VERSIONSTR "." EFI_ARCH
 #endif
 
+#ifndef ARCH_INDEPEND
 #define FALLBACK L"\\fb" EFI_ARCH L".efi"
 #define MOK_MANAGER L"\\mm" EFI_ARCH L".efi"
+#else
+#define FALLBACK L"\\fallback.efi"
+#define MOK_MANAGER L"\\MokManager.efi"
+#endif
 
 #if defined(VENDOR_DB_FILE)
 # define vendor_authorized vendor_db


### PR DESCRIPTION
Since we only build the 64-bit binaries, we don't have the issue of the mixed architecture binaries in the same directory. Besides, we will use the same install script for x86_64 and AArch64. It's easier to maintain the script with the same names.

Signed-off-by: Gary Lin <glin@suse.com>
Signed-off-by: Dennis Tseng <dennis.tseng@suse.com>