### PR TITLE
Shim 15.7 version update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 default : all
 
 NAME		= shim
-VERSION		= 15.6
+VERSION		= 15.7
 ifneq ($(origin RELEASE),undefined)
 DASHRELEASE	?= -$(RELEASE)
 else

--- a/data/sbat.csv
+++ b/data/sbat.csv
@@ -1,2 +1,2 @@
 sbat,1,SBAT Version,sbat,1,https://github.com/rhboot/shim/blob/main/SBAT.md
-shim,2,UEFI shim,shim,1,https://github.com/rhboot/shim
+shim,3,UEFI shim,shim,1,https://github.com/rhboot/shim

--- a/include/sbat_var_defs.h
+++ b/include/sbat_var_defs.h
@@ -3,6 +3,9 @@
 #ifndef SBAT_VAR_DEFS_H_
 #define SBAT_VAR_DEFS_H_
 
+/*
+ * This is the entry for the sbat data format
+ */
 #define SBAT_VAR_SIG "sbat,"
 #define SBAT_VAR_VERSION "1,"
 #define SBAT_VAR_ORIGINAL_DATE "2021030218"
@@ -22,14 +25,18 @@
 	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_LATEST_DATE "\n" \
 	SBAT_VAR_LATEST_REVOCATIONS
 #else /* !ENABLE_SHIM_DEVEL */
-#define SBAT_VAR_PREVIOUS_DATE SBAT_VAR_ORIGINAL_DATE
-#define SBAT_VAR_PREVIOUS_REVOCATIONS
+/*
+ * As of 2022-11-16, most folks (including Ubuntu, SUSE, openSUSE) don't have
+ * a "shim,2" yet, so adding that here would end up unbootable.
+ */
+#define SBAT_VAR_PREVIOUS_DATE "2022052400"
+#define SBAT_VAR_PREVIOUS_REVOCATIONS "grub,2\n"
 #define SBAT_VAR_PREVIOUS \
 	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_PREVIOUS_DATE "\n" \
 	SBAT_VAR_PREVIOUS_REVOCATIONS
 
-#define SBAT_VAR_LATEST_DATE "2022052400"
-#define SBAT_VAR_LATEST_REVOCATIONS "shim,2\ngrub,2\n"
+#define SBAT_VAR_LATEST_DATE "2022111500"
+#define SBAT_VAR_LATEST_REVOCATIONS "shim,2\ngrub,3\n"
 #define SBAT_VAR_LATEST \
 	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_LATEST_DATE "\n" \
 	SBAT_VAR_LATEST_REVOCATIONS

--- a/model.c
+++ b/model.c
@@ -8,16 +8,18 @@
 /* This is so vim's Syntastic checker won't yell about all these. */
 extern void __coverity_string_size_sanitize__(int);
 extern void __coverity_negative_sink__(int);
-extern void __coverity_alloc_nosize__(void);
+extern void *__coverity_alloc_nosize__(void);
+extern void __coverity_writeall0__(void *);
 extern void *__coverity_alloc__(int);
 extern void __coverity_sleep__();
 extern void __coverity_tainted_data_sanitize__(void *);
+extern void __coverity_free__(void *);
 #endif
 
 void *
 OBJ_dup(void *o)
 {
-	__coverity_alloc_nosize__();
+	return __coverity_alloc_nosize__();
 }
 
 int
@@ -131,6 +133,23 @@ AllocatePages(EFI_ALLOCATE_TYPE Type,
 		return EFI_SUCCESS;
 	}
 	return EFI_OUT_OF_RESOURCES;
+}
+
+void *
+AllocateZeroPool(int sz)
+{
+	void *ptr;
+
+	__coverity_negative_sink__(sz);
+	ptr = __coverity_alloc__(sz);
+	__coverity_writeall0__(ptr);
+	return ptr;
+}
+
+void
+FreePool(void *ptr)
+{
+	__coverity_free__(ptr);
 }
 
 // vim:fenc=utf-8:tw=75


### PR DESCRIPTION
Final changes for shim-15.7 (not including tagging)
- bump grub's required SBAT_LEVEL version
- bump shim's .sbat version
- minor coverity related changes