### PR TITLE
Fix typo in preserve_sbat_uefi_variable()

### DIFF
--- a/sbat.c
+++ b/sbat.c
@@ -362,7 +362,7 @@ preserve_sbat_uefi_variable(UINT8 *sbat, UINTN sbatsize, UINT32 attributes,
 
 	/* current metadata is not currupt somehow */
 	if (!check_sbat_var_attributes(attributes) ||
-               sbatsize < strlen(SBAT_VAR_ORIGINAL) ||
+               sbatsize < strlen(SBAT_VAR_SIG) ||
 	       strncmp(sbatc, SBAT_VAR_SIG, strlen(SBAT_VAR_SIG)))
 		return false;
 


### PR DESCRIPTION
During verification of current metadata curruption it was intended to verify whether component name matches SBAT_VAR_SIG, so sbat variable should at least has a length of SBAT_VAR_SIG, not SBAT_VAR_ORIGINAL. Current metadata version is verified later.