### PR TITLE
Drop invalid calls to `CRYPTO_set_mem_functions`

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1275,24 +1275,10 @@ EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
 	return EFI_SUCCESS;
 }
 
-static void *
-ossl_malloc(size_t num)
-{
-	return AllocatePool(num);
-}
-
-static void
-ossl_free(void *addr)
-{
-	FreePool(addr);
-}
-
 static void
 init_openssl(void)
 {
-	CRYPTO_set_mem_functions(ossl_malloc, NULL, ossl_free);
 	OPENSSL_init();
-	CRYPTO_set_mem_functions(ossl_malloc, NULL, ossl_free);
 	ERR_load_ERR_strings();
 	ERR_load_BN_strings();
 	ERR_load_RSA_strings();


### PR DESCRIPTION
These calls did not check the return value. If they had, it would have shown that the calls were failing due to passing `NULL` for the `realloc` function pointer. That [causes an early return](https://github.com/rhboot/shim/blob/main/Cryptlib/OpenSSL/crypto/mem.c#L157), so the calls weren't actually doing anything.

The `malloc`/`realloc`/`free` functions defined in [Cryptlib/SysCall/BaseMemAllocation.c](https://github.com/rhboot/shim/blob/main/Cryptlib/SysCall/BaseMemAllocation.c) are what actually get used, so just drop the explicit call to `CRYPTO_set_mem_functions`.