### PR TITLE
test-sbat: Fix exit code

### DIFF
--- a/test-sbat.c
+++ b/test-sbat.c
@@ -1187,7 +1187,7 @@ main(void)
 
 	test(test_sbat_var_asciz);
 
-	return 0;
+	return status;
 }
 
 // vim:fenc=utf-8:tw=75:noet


### PR DESCRIPTION
Fix the `main` function in `test-sbat.c` to return the `status` variable like the other `test-*.c` files.

Signed-off-by: Nicholas Bishop <nicholasbishop@google.com>