### PR TITLE
Remove sanity check for length when updating mem attrs

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -937,7 +937,7 @@ get_mem_attrs (uintptr_t addr, size_t size, uint64_t *attrs)
 	if (EFI_ERROR(efi_status) || !proto)
 		return efi_status;
 
-	if (physaddr & 0xfff || size & 0xfff || size == 0 || attrs == NULL) {
+	if (physaddr & EFI_PAGE_MASK || size == 0 || attrs == NULL) {
 		dprint(L"%a called on 0x%llx-0x%llx and attrs 0x%llx\n",
 		       __func__, (unsigned long long)physaddr,
 		       (unsigned long long)(physaddr+size-1),
@@ -971,7 +971,7 @@ update_mem_attrs(uintptr_t addr, uint64_t size,
 		       (unsigned long long)addr, (unsigned long long)size,
 		       &before, efi_status);
 
-	if (physaddr & 0xfff || size & 0xfff || size == 0) {
+	if (physaddr & EFI_PAGE_MASK || size == 0) {
 		dprint(L"%a called on 0x%llx-0x%llx (size 0x%llx) +%a%a%a -%a%a%a\n",
 		       __func__, (unsigned long long)physaddr,
 		       (unsigned long long)(physaddr + size - 1),


### PR DESCRIPTION
According to the DXE spec, the BaseAddress must be page-aligned, while the Length is not necessarily page-aligned. Hence, the sanity checks for size in update_mem_attrs() and get_mem_attrs in pe.c are removed.

_DXE Architectural Protocols Platform Initialization Specification, Vol. 2 EFI_CPU_ARCH_PROTOCOL.SetMemoryAttributes()
Summary
    Change a memory region to support specified memory attributes.
Prototype
    typedef
    EFI_STATUS
    (EFIAPI *EFI_CPU_SET_MEMORY_ATTRIBUTES) (
        IN CONST EFI_CPU_ARCH_PROTOCOL *This,
        IN EFI_PHYSICAL_ADDRESS BaseAddress,
        IN UINT64 Length,
        IN UINT64 Attributes
    );
Parameters
    This
        The EFI_CPU_ARCH_PROTOCOL instance.
    BaseAddress
        The physical address that is the start address of a memory region.
        EFI_PHYSICAL_ADDRESS is defined in the AllocatePages() function
        description in the UEFI 2.0 specification.
    Length
        The size in bytes of the memory region.
    Attributes
        A bit mask that specifies the memory region attributes.
        GetMemoryMap() for the set of legal attribute bits._

Signed-off-by: Dennis Tseng <dennis.tseng@suse.com>