### PR TITLE
Cryptlib: Track allocation sizes to fix realloc

### DIFF
--- a/Cryptlib/SysCall/BaseMemAllocation.c
+++ b/Cryptlib/SysCall/BaseMemAllocation.c
@@ -19,20 +19,63 @@ WITHOUT WARRANTIES OR REPRESENTATIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED.
 // -- Memory-Allocation Routines --
 //
 
+/* Prefix allocations with the allocation's total size.
+ *
+ * This is used to implement `realloc`, which needs to know the
+ * allocation's current size so that the data can be copied over to the
+ * new allocation.
+ */
+struct AllocWithSize {
+  /* Size of the whole allocation, including this `size` field.
+   *
+   * Allocations returned by AllocatePool are always eight-byte aligned
+   * (according to the UEFI spec), so use an eight-byte `size` field to
+   * make the `data` field also eight-byte aligned. */
+  UINT64 size;
+
+  /* The beginning of the allocation returned to the caller of malloc.
+   *
+   * The pointer to this data is what will then get passed into realloc
+   * and free; those functions use ptr_to_alloc_with_size to get the
+   * pointer to the underlying pool allocation. */
+  UINT8 data[0];
+};
+
+/* Convert a `ptr` (as returned by malloc) to an AllocWithSize by
+ * subtracting eight bytes. */
+static struct AllocWithSize *ptr_to_alloc_with_size (void *ptr) {
+  UINT8 *cptr = (UINT8*) ptr;
+  return (struct AllocWithSize*) (cptr - sizeof(struct AllocWithSize));
+}
+
 /* Allocates memory blocks */
 void *malloc (size_t size)
 {
-  return AllocatePool ((UINTN) size);
+  UINTN alloc_size = (UINTN) (size + sizeof(struct AllocWithSize));
+
+  struct AllocWithSize *alloc = AllocatePool (alloc_size);
+  if (alloc) {
+    alloc->size = alloc_size;
+    return alloc->data;
+  } else {
+    return NULL;
+  }
 }
 
 /* Reallocate memory blocks */
 void *realloc (void *ptr, size_t size)
 {
-  //
-  // BUG: hardcode OldSize == size! We have no any knowledge about
-  // memory size of original pointer ptr.
-  //
-  return ReallocatePool (ptr, (UINTN) size, (UINTN) size);
+  struct AllocWithSize *alloc = ptr_to_alloc_with_size (ptr);
+  UINTN old_size = alloc->size;
+  UINTN new_size = (UINTN) (size + sizeof(struct AllocWithSize));
+
+  alloc = ReallocatePool (alloc, old_size, new_size);
+  if (alloc) {
+    alloc->size = new_size;
+    return alloc->data;
+  } else {
+    return NULL;
+  }
 }
 
 /* De-allocates or frees a memory block */
@@ -43,6 +86,8 @@ void free (void *ptr)
   // is not true of FreePool() below, so protect it.
   //
   if (ptr != NULL) {
+    ptr = ptr_to_alloc_with_size (ptr);
+
     FreePool (ptr);
   }
 }


### PR DESCRIPTION
Implementing `realloc` properly requires knowing the size of the allocation, so that the memory in the old allocation can be copied over to the new allocation. This information isn't provided by UEFI or gnu-efi. Previously the implementation of `realloc` copied over the new allocation size's number of bytes, which can fail with stricter memory protections.

Fix by expanding each allocation by 8 bytes, and storing the size of the allocation in the first 8 bytes of the allocation. The pointer returned by `malloc` is then 8 bytes after the actual pool allocation. The `realloc` and `free` functions subtract 8 bytes to get the "real" allocation pointer again for passing to the `ReallocatePool` and `FreePool` functions. The `realloc` function reads the original allocation size from the beginning of the allocation so that the correct number of bytes are copied to the new allocation.

Fixes https://github.com/rhboot/shim/issues/538

Signed-off-by: Nicholas Bishop <nicholasbishop@google.com>