### PR TITLE
Don't loop forever in load_certs() with buggy firmware

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1483,11 +1483,21 @@ load_certs(EFI_HANDLE image_handle)
 	}
 
 	while (1) {
-		int old = buffersize;
+		UINTN old = buffersize;
 		efi_status = dir->Read(dir, &buffersize, buffer);
 		if (efi_status == EFI_BUFFER_TOO_SMALL) {
-			buffer = ReallocatePool(buffer, old, buffersize);
-			continue;
+			if (buffersize != old) {
+				buffer = ReallocatePool(buffer, old, buffersize);
+				if (buffer == NULL) {
+					perror(L"Failed to read directory %s - %r\n",
+					       PathName, EFI_OUT_OF_RESOURCES);
+					goto done;
+				}
+				continue;
+			}
+			perror(L"Failed to read directory %s - buggy firmware\n",
+			       PathName);
+			goto done;
 		} else if (EFI_ERROR(efi_status)) {
 			perror(L"Failed to read directory %s - %r\n", PathName,
 			       efi_status);


### PR DESCRIPTION
On DELL R350 booting DVD through RFS with BIOS 1.4.2 in Secure Boot, firmware returns *EFI_BUFFER_TOO_SMALL* but with new *buffersize* set to 0, which causes the `load_certs()` code to loop forever:

~~~
while (1) {
    efi_status = dir->Read(dir, &buffersize, buffer);
    if (efi_status == EFI_BUFFER_TOO_SMALL) {
        ...
        continue;
    }
    ...
}
~~~

This commit prevents such infinite loop. The new code doesn't check if new *buffersize* is 0 only, but if it's different from *old* one we passed, which may cover more buggy firmware cases at minor cost.
