### PR TITLE
 Issue #524 Shim unable to locate grubx64 in PXE boot mode when grubx…

### DIFF
--- a/netboot.c
+++ b/netboot.c
@@ -263,9 +263,10 @@ static EFI_STATUS parseDhcp4()
 	UINT8 *dir = pkt_v4->BootpBootFile;
 
 	for (i = dir_len; i >= 0; i--) {
-		if (dir[i] == '/')
-			break;
+        if ((dir[i] == '/') || (dir[i] == '\\'))
+            break;
 	}
+
 	dir_len = (i >= 0) ? i + 1 : 0;
 
 	full_path = AllocateZeroPool(dir_len + template_len);
@@ -277,6 +278,11 @@ static EFI_STATUS parseDhcp4()
 		strncpy(full_path, (CHAR8 *)dir, dir_len);
 		if (full_path[dir_len-1] == '/' && template[0] == '/')
 			full_path[dir_len-1] = '\0';
+		// check for paths with  back slash condition
+		if (full_path[dir_len-1] == '\\' && template[0] == '/') {
+			full_path[dir_len-1] = '\0';
+			template[0] = '\\';
+		}
 	}
 	if (dir_len == 0 && dir[0] != '/' && template[0] == '/')
 		template_ofs++;


### PR DESCRIPTION
…64 is stored in a different file path.

 Problem: grubx64 not found when file path contains '\'

 Root Cause: parseDhcp4 function is unable to handle file path with '\'

 Changes to be committed:
	modified:   netboot.c