### PR TITLE
Rename 'msecs' to 'usecs' to avoid potential confusion

### DIFF
--- a/fallback.c
+++ b/fallback.c
@@ -1006,7 +1006,7 @@ try_start_first_option(EFI_HANDLE parent_image_handle)
 	EFI_HANDLE image_handle;
 
 	if (get_fallback_verbose()) {
-		int fallback_verbose_wait = 500000; /* default to 0.5s */
+		unsigned long fallback_verbose_wait = 500000; /* default to 0.5s */
 #ifdef FALLBACK_VERBOSE_WAIT
 		fallback_verbose_wait = FALLBACK_VERBOSE_WAIT;
 #endif
@@ -1211,7 +1211,7 @@ reset:
 	console_print(L"Reset System\n");
 
 	if (get_fallback_verbose()) {
-		int fallback_verbose_wait = 500000; /* default to 0.5s */
+		unsigned long fallback_verbose_wait = 500000; /* default to 0.5s */
 #ifdef FALLBACK_VERBOSE_WAIT
 		fallback_verbose_wait = FALLBACK_VERBOSE_WAIT;
 #endif

--- a/fallback.c
+++ b/fallback.c
@@ -1013,7 +1013,7 @@ try_start_first_option(EFI_HANDLE parent_image_handle)
 		console_print(L"Verbose enabled, sleeping for %d mseconds... "
 			      L"Press the Pause key now to hold for longer.\n",
 			      fallback_verbose_wait);
-		msleep(fallback_verbose_wait);
+		usleep(fallback_verbose_wait);
 	}
 
 	if (!first_new_option) {
@@ -1036,7 +1036,7 @@ try_start_first_option(EFI_HANDLE parent_image_handle)
 		}
 		console_print(L"\n");
 
-		msleep(500000000);
+		usleep(500000000);
 		return efi_status;
 	}
 
@@ -1051,7 +1051,7 @@ try_start_first_option(EFI_HANDLE parent_image_handle)
 	efi_status = BS->StartImage(image_handle, NULL, NULL);
 	if (EFI_ERROR(efi_status)) {
 		console_print(L"StartImage failed: %r\n", efi_status);
-		msleep(500000000);
+		usleep(500000000);
 	}
 	return efi_status;
 }
@@ -1218,7 +1218,7 @@ reset:
 		console_print(L"Verbose enabled, sleeping for %d mseconds... "
 			      L"Press the Pause key now to hold for longer.\n",
 			      fallback_verbose_wait);
-		msleep(fallback_verbose_wait);
+		usleep(fallback_verbose_wait);
 	}
 
 	RT->ResetSystem(EfiResetCold, EFI_SUCCESS, 0, NULL);

--- a/include/asm.h
+++ b/include/asm.h
@@ -40,7 +40,7 @@ static inline void wait_for_debug(void)
 {
         uint64_t a, b;
         int x;
-        extern void msleep(unsigned long msecs);
+        extern void msleep(unsigned long usecs);
 
         a = read_counter();
         for (x = 0; x < 1000; x++) {

--- a/include/asm.h
+++ b/include/asm.h
@@ -40,11 +40,11 @@ static inline void wait_for_debug(void)
 {
         uint64_t a, b;
         int x;
-        extern void msleep(unsigned long usecs);
+        extern void usleep(unsigned long usecs);
 
         a = read_counter();
         for (x = 0; x < 1000; x++) {
-                msleep(1000);
+                usleep(1000);
                 b = read_counter();
                 if (a != b)
                         break;

--- a/include/console.h
+++ b/include/console.h
@@ -122,7 +122,7 @@ extern EFI_STATUS EFIAPI vdprint_(const CHAR16 *fmt, const char *file, int line,
 extern EFI_STATUS print_crypto_errors(EFI_STATUS rc, char *file, const char *func, int line);
 #define crypterr(rc) print_crypto_errors((rc), __FILE__, __func__, __LINE__)
 
-extern VOID msleep(unsigned long msecs);
+extern VOID msleep(unsigned long usecs);
 
 /* This is used in various things to determine if we should print to the
  * console */

--- a/include/console.h
+++ b/include/console.h
@@ -122,7 +122,7 @@ extern EFI_STATUS EFIAPI vdprint_(const CHAR16 *fmt, const char *file, int line,
 extern EFI_STATUS print_crypto_errors(EFI_STATUS rc, char *file, const char *func, int line);
 #define crypterr(rc) print_crypto_errors((rc), __FILE__, __func__, __LINE__)
 
-extern VOID msleep(unsigned long usecs);
+extern VOID usleep(unsigned long usecs);
 
 /* This is used in various things to determine if we should print to the
  * console */

--- a/include/console.h
+++ b/include/console.h
@@ -122,7 +122,9 @@ extern EFI_STATUS EFIAPI vdprint_(const CHAR16 *fmt, const char *file, int line,
 extern EFI_STATUS print_crypto_errors(EFI_STATUS rc, char *file, const char *func, int line);
 #define crypterr(rc) print_crypto_errors((rc), __FILE__, __func__, __LINE__)
 
+#ifndef SHIM_UNIT_TEST
 extern VOID usleep(unsigned long usecs);
+#endif
 
 /* This is used in various things to determine if we should print to the
  * console */

--- a/lib/console.c
+++ b/lib/console.c
@@ -743,11 +743,13 @@ setup_verbosity(VOID)
 	setup_console(-1);
 }
 
+#ifndef SHIM_UNIT_TEST
 VOID
 usleep(unsigned long usecs)
 {
 	BS->Stall(usecs);
 }
+#endif
 
 /* This is used in various things to determine if we should print to the
  * console */

--- a/lib/console.c
+++ b/lib/console.c
@@ -744,9 +744,9 @@ setup_verbosity(VOID)
 }
 
 VOID
-msleep(unsigned long msecs)
+msleep(unsigned long usecs)
 {
-	BS->Stall(msecs);
+	BS->Stall(usecs);
 }
 
 /* This is used in various things to determine if we should print to the

--- a/lib/console.c
+++ b/lib/console.c
@@ -744,7 +744,7 @@ setup_verbosity(VOID)
 }
 
 VOID
-msleep(unsigned long usecs)
+usleep(unsigned long usecs)
 {
 	BS->Stall(usecs);
 }

--- a/model.c
+++ b/model.c
@@ -54,7 +54,7 @@ gcm_gmult_4bit(u64 Xi[2], u128 Htable[16])
 }
 
 void
-msleep(int n)
+usleep(int n)
 {
 	__coverity_sleep__();
 }

--- a/replacements.c
+++ b/replacements.c
@@ -90,7 +90,7 @@ replacement_start_image(EFI_HANDLE image_handle, UINTN *exit_data_size, CHAR16 *
 				console_print(L"Something has gone seriously wrong: %r\n",
 					      efi_status2);
 				console_print(L"shim cannot continue, sorry.\n");
-				msleep(5000000);
+				usleep(5000000);
 				RT->ResetSystem(EfiResetShutdown,
 						EFI_SECURITY_VIOLATION,
 						0, NULL);
@@ -118,7 +118,7 @@ exit_boot_services(EFI_HANDLE image_key, UINTN map_key)
 
 	console_print(L"Bootloader has not verified loaded image.\n");
 	console_print(L"System is compromised.  halting.\n");
-	msleep(5000000);
+	usleep(5000000);
 	RT->ResetSystem(EfiResetShutdown, EFI_SECURITY_VIOLATION, 0, NULL);
 	return EFI_SECURITY_VIOLATION;
 }
@@ -143,7 +143,7 @@ do_exit(EFI_HANDLE ImageHandle, EFI_STATUS ExitStatus,
 			console_print(L"Something has gone seriously wrong: %r\n",
 				      efi_status2);
 			console_print(L"shim cannot continue, sorry.\n");
-			msleep(5000000);
+			usleep(5000000);
 			RT->ResetSystem(EfiResetShutdown,
 					EFI_SECURITY_VIOLATION, 0, NULL);
 		}

--- a/shim.c
+++ b/shim.c
@@ -1207,7 +1207,7 @@ EFI_STATUS init_grub(EFI_HANDLE image_handle)
 		efi_status = start_image(image_handle, MOK_MANAGER);
 		if (EFI_ERROR(efi_status)) {
 			console_print(L"start_image() returned %r\n", efi_status);
-			msleep(2000000);
+			usleep(2000000);
 			return efi_status;
 		}
 
@@ -1222,7 +1222,7 @@ EFI_STATUS init_grub(EFI_HANDLE image_handle)
 		console_print(
 			L"start_image() returned %r, falling back to default loader\n",
 			efi_status);
-		msleep(2000000);
+		usleep(2000000);
 		load_options = NULL;
 		load_options_size = 0;
 		efi_status = start_image(image_handle, DEFAULT_LOADER);
@@ -1230,7 +1230,7 @@ EFI_STATUS init_grub(EFI_HANDLE image_handle)
 
 	if (EFI_ERROR(efi_status)) {
 		console_print(L"start_image() returned %r\n", efi_status);
-		msleep(2000000);
+		usleep(2000000);
 	}
 
 	return efi_status;
@@ -1647,7 +1647,7 @@ devel_egress(devel_egress_action action UNUSED)
 	console_print(L"Waiting to %a...", reasons[action]);
 	for (size_t sleepcount = 0; sleepcount < 10; sleepcount++) {
 		console_print(L"%d...", 10 - sleepcount);
-		msleep(1000000);
+		usleep(1000000);
 	}
 	console_print(L"\ndoing %a\n", action);
 
@@ -1785,7 +1785,7 @@ die:
 #if defined(ENABLE_SHIM_DEVEL)
 		devel_egress(COLD_RESET);
 #else
-		msleep(5000000);
+		usleep(5000000);
 		RT->ResetSystem(EfiResetShutdown, EFI_SECURITY_VIOLATION,
 				0, NULL);
 #endif
@@ -1802,7 +1802,7 @@ die:
 	 */
 	if (user_insecure_mode) {
 		console_print(L"Booting in insecure mode\n");
-		msleep(2000000);
+		usleep(2000000);
 	}
 
 	/*


### PR DESCRIPTION
As suggested in https://github.com/rhboot/shim/issues/251.

The function `msleep` uses `gBS->Stall` which waits for a specified number of microseconds.

Reference: https://edk2-docs.gitbook.io/edk-ii-uefi-driver-writer-s-guide/5_uefi_services/51_services_that_uefi_drivers_commonly_use/517_stall

This reference even mentions an example slepping for 10 microseconds: `// Wait 10 uS`. Notice the letter 'u'.

Therefore it's a good idea to call the argument `msleep` uses 'usecs' rather than 'msecs' so no one confuses it with miliseconds.