### PR TITLE
Add more clear comments when decoding asn.1 tag and length bytes

### DIFF
--- a/Cryptlib/Pk/CryptAuthenticode.c
+++ b/Cryptlib/Pk/CryptAuthenticode.c
@@ -142,7 +142,7 @@ AuthenticodeVerify (
     //
     ContentSize = (UINTN) (Asn1Byte & 0x7F);
     //
-    // Skip the SEQUENCE Tag;
+    // Skip the SEQUENCE Tag and the Length;
     //
     SpcIndirectDataContent += 2;
 
@@ -152,7 +152,7 @@ AuthenticodeVerify (
     //
     ContentSize = (UINTN) (*(UINT8 *)(SpcIndirectDataContent + 2));
     //
-    // Skip the SEQUENCE Tag;
+    // Skip the SEQUENCE Tag and the Length;
     //
     SpcIndirectDataContent += 3;
 
@@ -163,7 +163,7 @@ AuthenticodeVerify (
     ContentSize = (UINTN) (*(UINT8 *)(SpcIndirectDataContent + 2));
     ContentSize = (ContentSize << 8) + (UINTN)(*(UINT8 *)(SpcIndirectDataContent + 3));
     //
-    // Skip the SEQUENCE Tag;
+    // Skip the SEQUENCE Tag and the Length;
     //
     SpcIndirectDataContent += 4;
 


### PR DESCRIPTION
Actually, 
```
SpcIndirectDataContent += 2;
SpcIndirectDataContent += 3;
SpcIndirectDataContent += 4;
```
will skip Tag and Length fields simultaneously, rather then just skip Tag.
Related comments are modified for easier tracing thereafter.