### PR TITLE
Use -Wno-unused-but-set-variable for Cryptlib and OpenSSL

### DIFF
--- a/Cryptlib/Makefile
+++ b/Cryptlib/Makefile
@@ -11,7 +11,8 @@ INCLUDES	= -I$(CRYPTDIR) -I$(CRYPTDIR)/Include \
 		  -isystem $(TOPDIR)/include/system \
 		  -isystem $(shell $(CC) -print-file-name=include)
 
-WARNFLAGS	+= -Wno-unused-parameter
+WARNFLAGS	+= -Wno-unused-parameter \
+		   -Wno-unused-but-set-variable
 
 CFLAGS		= $(FEATUREFLAGS) \
 		  $(OPTIMIZATIONS) \

--- a/Cryptlib/OpenSSL/Makefile
+++ b/Cryptlib/OpenSSL/Makefile
@@ -23,7 +23,7 @@ FEATUREFLAGS	+= -nostdinc
 WARNFLAGS	+= -Wno-empty-body \
 		   -Wno-implicit-fallthrough \
 		   $(if $(findstring gcc,$(CC)),-Wno-old-style-declaration) \
-		   $(if $(findstring gcc,$(CC)),-Wno-unused-but-set-variable) \
+		   -Wno-unused-but-set-variable \
 		   -Wno-unused-parameter
 
 CFLAGS		= $(FEATUREFLAGS) \


### PR DESCRIPTION
Cryptlib and OpenSSL both currently throw warnings with some compilers using -Wunused-but-set-variable:

  clang -std=gnu11 -ggdb -ffreestanding -fmacro-prefix-map=/home/pjones/devel/github.com/shim/main/= -fno-stack-protector -fno-strict-aliasing -fpic -fshort-wchar -nostdinc -m64 -mno-mmx -mno-sse -mno-red-zone  -Os -Wall -Wextra -Wno-missing-field-initializers -Wno-unused-parameter -Werror -I/home/pjones/devel/github.com/shim/main/Cryptlib -I/home/pjones/devel/github.com/shim/main/Cryptlib/Include -I/home/pjones/devel/github.com/shim/main/gnu-efi/inc -I/home/pjones/devel/github.com/shim/main/gnu-efi/inc/x86_64 -I/home/pjones/devel/github.com/shim/main/gnu-efi/inc/protocol -isystem /home/pjones/devel/github.com/shim/main/include/system -isystem /usr/lib64/clang/16/include -DMDE_CPU_X64   -c -o Pk/CryptX509.o Pk/CryptX509.c
Pk/CryptX509.c:94:19: error: variable 'Index' set but not used [-Werror,-Wunused-but-set-variable]
    UINTN           Index;
                    ^
  clang -std=gnu11 -ggdb -ffreestanding -fmacro-prefix-map=/home/pjones/devel/github.com/shim/main/= -fno-stack-protector -fno-strict-aliasing -fpic -fshort-wchar -nostdinc -m64 -mno-mmx -mno-sse -mno-red-zone  -Os -Wall -Wextra -Wno-missing-field-initializers -Wno-empty-body -Wno-implicit-fallthrough   -Wno-unused-parameter -Werror -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL -I/home/pjones/devel/github.com/shim/main/Cryptlib -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL/Include/ -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL/crypto -I/home/pjones/devel/github.com/shim/main/Cryptlib/Include -I/home/pjones/devel/github.com/shim/main/gnu-efi/inc -I/home/pjones/devel/github.com/shim/main/gnu-efi/inc/x86_64 -I/home/pjones/devel/github.com/shim/main/gnu-efi/inc/protocol -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL/crypto/asn1 -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL/crypto/evp -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL/crypto/modes -I/home/pjones/devel/github.com/shim/main/Cryptlib/OpenSSL/crypto/include -isystem /home/pjones/devel/github.com/shim/main/include/system -isystem /usr/lib64/clang/16/include -DL_ENDIAN -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -DOPENSSL_SMALL_FOOTPRINT -DPEDANTIC -DMDE_CPU_X64   -c -o crypto/asn1/t_x509.o crypto/asn1/t_x509.c
crypto/asn1/t_x509.c:504:18: error: variable 'l' set but not used [-Werror,-Wunused-but-set-variable]
      int ret = 0, l, i;
                   ^

Since we normally build with -Werror, these cause builds to fail in these cases.  While the bad code should be addressed, it appears generally safe, so we should solve it upstream.

This patch adds -Wno-unused-but-set-variable to the Cryptlib Makefile, and removes the conditionalization on gcc in the OpenSSL Makefile, as clang now has this argument, and since we don't support building with clang for the final build, it's useful to have clang-based tools working.