### PR TITLE
Minor housekeeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ Make.local
 /.cache/
 /certdb/
 /compile_commands.json
+/compile_commands.events.json
 /cov-int/
 /post-process-pe
 /random.bin

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,10 @@ ifneq ($(origin EFI_PATH),undefined)
 	$(error EFI_PATH is no longer supported, you must build using the supplied copy of gnu-efi)
 endif
 
+compile_commands.json : Makefile Make.rules Make.defaults 
+	make clean
+	bear -- make COMPILER=clang test all
+
 update :
 	git submodule update --init --recursive
 
@@ -322,7 +326,7 @@ clean-lib-objs:
 
 clean-shim-objs:
 	@rm -rvf $(TARGET) *.o $(SHIM_OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb $(BOOTCSVNAME)
-	@rm -vf *.debug *.so *.efi *.efi.* *.tar.* version.c buildid post-process-pe
+	@rm -vf *.debug *.so *.efi *.efi.* *.tar.* version.c buildid post-process-pe compile_commands.json
 	@rm -vf Cryptlib/*.[oa] Cryptlib/*/*.[oa]
 	@if [ -d .git ] ; then git clean -f -d -e 'Cryptlib/OpenSSL/*'; fi
 

--- a/cert.S
+++ b/cert.S
@@ -52,3 +52,4 @@ vendor_deauthorized:
 #endif
 .Lvendor_deauthorized_end:
 .Lcert_table_end:
+	.section .note.GNU-stack,"a"

--- a/include/console.h
+++ b/include/console.h
@@ -106,8 +106,8 @@ extern UINT32 verbose;
 	dprint_(L"%a:%d:%a() " fmt, __FILE__, __LINE__ - 1, __func__, \
 	        ##__VA_ARGS__)
 #else
-#define dprint_(...)
-#define dprint(fmt, ...)
+#define dprint_(...) ({ ; })
+#define dprint(fmt, ...) ({ ; })
 #endif
 
 extern EFI_STATUS EFIAPI vdprint_(const CHAR16 *fmt, const char *file, int line,

--- a/sbat_var.S
+++ b/sbat_var.S
@@ -20,3 +20,4 @@ sbat_var_payload_header:
 .Lsbat_var_latest:
 	.ascii SBAT_VAR_LATEST
 	.byte 0
+	.section .note.GNU-stack,"a"


### PR DESCRIPTION
This is a small collection of minor changes:
- make rules to generate compile_commands.json, which is used by some editors for real-time error checking
- add gnu-stack notes to all our .S files, which reduces pointless compiler warnings
- minor modifications to dprintf() to support some test cases to be introduced later.