### PR TITLE
Size should minus 1 when calculating 'RelocBaseEnd'

### DIFF
--- a/pe-relocate.c
+++ b/pe-relocate.c
@@ -75,7 +75,7 @@ relocate_coff (PE_COFF_LOADER_IMAGE_CONTEXT *context,
 	/* RelocBaseEnd here is the address of the first entry /past/ the
 	 * table.  */
 	RelocBaseEnd = ImageAddress(orig, size, Section->PointerToRawData +
-						context->RelocDir->Size);
+						context->RelocDir->Size - 1);
 
 	if (!RelocBase && !RelocBaseEnd)
 		return EFI_SUCCESS;


### PR DESCRIPTION
```context->RelocDir->Size``` should minus one when calling ```ImageAddress()```. Otherwise
**RelocBaseEnd** will get NULL address after running ImageAddress() in which ```address=size```.
```
ImageAddress (void *image, uint64_t size, uint64_t address)
{
        uintptr_t img_addr;

        /* ensure our local pointer isn't bigger than our size */
        if (address >= size)   <---- address=size
                return NULL;
        ........
}
```

```RelocBaseEnd = ImageAddress(orig, size, Section->PointerToRawData + context->RelocDir->Size);```