### PR TITLE
Verify signature before verifying sbat levels

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -753,11 +753,11 @@ verify_buffer (char *data, int datasize,
 {
 	EFI_STATUS efi_status;
 
-	efi_status = verify_buffer_sbat(data, datasize, context);
+	efi_status = verify_buffer_authenticode(data, datasize, context, sha256hash, sha1hash);
 	if (EFI_ERROR(efi_status))
 		return efi_status;
 
-	return verify_buffer_authenticode(data, datasize, context, sha256hash, sha1hash);
+	return verify_buffer_sbat(data, datasize, context);
 }
 
 static int


### PR DESCRIPTION
Verifying the validity of a files signature can protect from an attacker creating a file that exploits a pontential issue in the sbat validation. If the singature is not checked first, an attacker can just create a file with a valid .sbat section and can still attack the signature valiation.