### PR TITLE
mok: Avoid underflow in maximum variable size calculation

### DIFF
--- a/mok.c
+++ b/mok.c
@@ -423,12 +423,20 @@ mirror_mok_db(CHAR16 *name, CHAR8 *name8, EFI_GUID *guid, UINT32 attrs,
 		}
 
 		/* The name counts towards the size of the variable */
-		max_var_sz -= (StrLen(namen) + 1) * 2;
+		SIZE_T namen_sz = (StrLen(namen) + 1) * 2;
+		if (max_var_sz > namen_sz)
+			max_var_sz -= namen_sz;
+		else
+			max_var_sz = 0;
 		dprint(L"max_var_sz - name: %lx\n", max_var_sz);
 
 		SIZE_T howmany;
-		howmany = MIN((max_var_sz - sizeof(*esl)) / esl->SignatureSize,
-			      (esl_end_pos - pos) / esl->SignatureSize);
+		if (max_var_sz > sizeof(*esl))
+			howmany = MIN((max_var_sz - sizeof(*esl)) / esl->SignatureSize,
+				      (esl_end_pos - pos) / esl->SignatureSize);
+		else
+			howmany = 0;
+
 		if (howmany == 0) {
 			/* No signatures from this ESL can be mirrored in to a
 			 * single variable, so skip it.


### PR DESCRIPTION
The code that mirrors MOK database to EFI variables gets the remaining variable storage size from the firmware and subtracts the size needed for any overhead to see if there is enough space to create a new entry.

However these calculations are on unsigned integer types, they can underflow and result in huge values when the firmware is about to run out of usable variable space. Explicitly check against this.