### PR TITLE
pe: Enhance debug report for update_mem_attrs

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -480,7 +480,7 @@ update_mem_attrs(uintptr_t addr, uint64_t size,
 		       &before, efi_status);
 
 	if (!IS_PAGE_ALIGNED(physaddr) || !IS_PAGE_ALIGNED(size) || size == 0) {
-		dprint(L"%a called on 0x%llx-0x%llx (size 0x%llx) +%a%a%a -%a%a%a\n",
+		perror(L"Invalid call %a(addr:0x%llx-0x%llx, size:0x%llx, +%a%a%a, -%a%a%a)\n",
 		       __func__, (unsigned long long)physaddr,
 		       (unsigned long long)(physaddr + size - 1),
 		       (unsigned long long)size,
@@ -490,6 +490,12 @@ update_mem_attrs(uintptr_t addr, uint64_t size,
 		       (clear_attrs & MEM_ATTR_R) ? "r" : "",
 		       (clear_attrs & MEM_ATTR_W) ? "w" : "",
 		       (clear_attrs & MEM_ATTR_X) ? "x" : "");
+		if (!IS_PAGE_ALIGNED(physaddr))
+			perror(L" addr is not page aligned\n");
+		if (!IS_PAGE_ALIGNED(size))
+			perror(L" size is not page aligned\n");
+		if (size == 0)
+			perror(L" size is 0\n");
 		return 0;
 	}
 


### PR DESCRIPTION
When memory attributes cannot be updated due to misalignment with 4K or when the size is 0, the debug printout lacks sufficient clarity to indicate the issue. To enhance troubleshooting, it is crucial to generate an error log that explicitly states the failure to execute the expected action. This error log will be visible even when the debug level log is not enabled, thereby significantly reducing debugging time.