### PR TITLE
make-certs: Handle missing OpenSSL installation

### DIFF
--- a/make-certs
+++ b/make-certs
@@ -7,6 +7,11 @@
 
 set -e
 
+if [[ ! -f `which openssl` ]]; then
+	echo "OpenSSL not found. Install it first, then run this script again."
+	exit 1
+fi
+
 DOMAIN=xn--u4h.net
 DAYS=365
 KEYTYPE=RSA


### PR DESCRIPTION
If there is no OpenSSL installation on the system, where the `make-certs` script is run at, no error message will be shown; instead the script will fail silently and no certificates will be generated.

This change introduces a simple check, if the `openssl` binary is present and informs the user, if it's missing, shortening debugging time from minutes to mere seconds.

A bashism has been used so a pretty message gets printed without moving the check to a section before `set -e`.