### PR TITLE
Fix build failed when using OVERRIDE_SECURITY_POLICY flag

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -143,6 +143,7 @@ POST_PROCESS_PE_FLAGS =
 
 ifneq ($(origin OVERRIDE_SECURITY_POLICY), undefined)
 	DEFINES	+= -DOVERRIDE_SECURITY_POLICY
+	export
 endif
 
 ifneq ($(origin REQUIRE_TPM), undefined)


### PR DESCRIPTION
Add ```export``` to export OVERRIDE_SECURITY_POLICY variable to sub-makefile in ```lib``` sub-directory to fix the build failed according to the description from issue #596 by [bryteise](https://github.com/bryteise)