### PR TITLE
Generate Authenticode for the entire PE file

### DIFF
--- a/pe.c
+++ b/pe.c
@@ -285,14 +285,16 @@ generate_hash(char *data, unsigned int datasize,
 			goto done;
 		}
 
-#if 1
-	}
-#else // we have to migrate to doing this later :/
 		SumOfBytesHashed += hashsize;
 	}
 
-	/* Hash all remaining data */
-	if (datasize > SumOfBytesHashed) {
+	/* Hash all remaining data. If SecDir->Size is > 0 this code should not
+	 * be entered.  If it is, there are still things to hash.  For a file
+	 * without a SecDir, we need to hash what remains. */
+	if (datasize > SumOfBytesHashed + context->SecDir->Size) {
+		char padbuf[8];
+		ZeroMem(padbuf, 8);
+
 		hashbase = data + SumOfBytesHashed;
 		hashsize = datasize - SumOfBytesHashed;
 
@@ -306,8 +308,17 @@ generate_hash(char *data, unsigned int datasize,
 		}
 
 		SumOfBytesHashed += hashsize;
+		hashsize = ALIGN_VALUE(SumOfBytesHashed, 8) - SumOfBytesHashed;
+
+		if (hashsize) {
+			if (!(Sha256Update(sha256ctx, padbuf, hashsize)) ||
+			    !(Sha1Update(sha1ctx, padbuf, hashsize))) {
+				perror(L"Unable to generate hash\n");
+				efi_status = EFI_OUT_OF_RESOURCES;
+				goto done;
+			}
+		}
 	}
-#endif
 
 	if (!(Sha256Final(sha256ctx, sha256hash)) ||
 	    !(Sha1Final(sha1ctx, sha1hash))) {


### PR DESCRIPTION
The Authenticode is a hash calculation that excludes parts of the PE file that are altered in the signing process itself.  The Authenticode for a PE file should be the same for both the signed and unsigned versions. Both sbsign and pesign have chosen to modify a portion of the PE file that falls outside the actual digital signature.  This is done by zero padding the end of the PE file to align the signature table that is later added.  After doing this padding, the new zero padded data is included within the Authenticode hash calculation.

Both pesign and sbsign can display the Authenticode for an unsigned binary with the padding included within the calculation.  Adding this hash to the MOK does not allow the program to run.  The pesign program also has an option to generate the Authenticode without the padding included. Adding this hash to the MOK also does NOT allow the program to run. When shim finds a PE file without a digital signature, it completely stops calculating the hash towards the end of the file.  Part of the file is excluded. Testing has shown that the last 3K of the file can be omitted from the calculation.

If the Authenticode is generated using Shim’s MokManager, it will calculate a hash without the last part and allow the program to run. Since the end of the file is not included within the calculation, other things could be added.

Fix all this by hashing the entire file that is outside the digital signature to calculate the Authenticode.  Also add zero padding when necessary to do the Authenticode calculation.  If the program is signed, this code should never be referenced.  However, if this code is entered by a signed PE file, there is potentially something nefarious going on.

link: https://blog.hansenpartnership.com/problems-with-tianocore-after-multi-sign-r14141-fixed/
link: https://github.com/osresearch/sbsigntools/commit/370abb7c49ec2a600f64fcbd441d9297124a5cb7
link: https://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git/commit/?id=592ec2188f7b9cf003fe7cb0835e93559f19156f