### PR TITLE
Force gcc to produce DWARF4 so that gdb can use it

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -109,7 +109,7 @@ INCLUDES	= -nostdinc \
 
 override DEFAULT_FEATUREFLAGS = \
 		-std=gnu11 \
-		-ggdb \
+		-ggdb -gdwarf-4 -gstrict-dwarf \
 		-ffreestanding \
 		$(shell $(CC) -fmacro-prefix-map=./=./ -E -x c /dev/null >/dev/null 2>&1 && echo -fmacro-prefix-map='$(TOPDIR)/=$(DEBUGSRC)') \
 		-fno-stack-protector \


### PR DESCRIPTION
Addresses #606.

I am not sure if the location where I have added the flags is ideal, though it does make shim debuggable again.