### PR TITLE
Drop unused EFI_IMAGE_SECURITY_DATABASE_GUID definition

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -52,8 +52,6 @@ extern struct {
 	UINT32 vendor_deauthorized_offset;
 } cert_table;
 
-#define EFI_IMAGE_SECURITY_DATABASE_GUID { 0xd719b2cb, 0x3d3a, 0x4596, { 0xa3, 0xbc, 0xda, 0xd0, 0x0e, 0x67, 0x65, 0x6f }}
-
 typedef enum {
 	DATA_FOUND,
 	DATA_NOT_FOUND,


### PR DESCRIPTION
The code actually uses EFI_SECURE_BOOT_DB_GUID which is defined in include/guid.h, drop the unused EFI_IMAGE_SECURITY_DATABASE_GUID define from shim.c