### PR TITLE
Process OVERRIDE_SECURITY_POLICY in lib/Makefile

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -31,6 +31,10 @@ ifeq ($(ARCH),arm)
 DEFINES		+= -DMDE_CPU_ARM
 endif
 
+ifneq ($(origin OVERRIDE_SECURITY_POLICY), undefined)
+	DEFINES	+= -DOVERRIDE_SECURITY_POLICY
+endif
+
 LDFLAGS		= -nostdlib -znocombreloc
 
 


### PR DESCRIPTION
Without this `make OVERRIDE_SECURITY_POLICY=1` fails with

```
ld: shim.o: in function `install_shim_protocols':
/home/mjsbeaton/shim_source/shim.c:1354: undefined reference to `security_policy_install'
ld: shim.o: in function `uninstall_shim_protocols':
/home/mjsbeaton/shim_source/shim.c:1376: undefined reference to `security_policy_uninstall'
```

Fixes issue #596 and is an alternative to PR #600.