### PR TITLE
Discard load-options that start with WINDOWS

### DIFF
--- a/load-options.c
+++ b/load-options.c
@@ -442,6 +442,14 @@ parse_load_options(EFI_LOADED_IMAGE *li)
 		}
 	}
 
+	/*
+	 * Windows bcdedit.exe puts "WINDOWS\0" (in 8-bit) in the beginning of
+	 * the options, so if we see that, we know it's not useful to us.
+	 */
+	if (li->LoadOptionsSize >= 8)
+		if (CompareMem(li->LoadOptions, "WINDOWS", 8) == 0)
+			return EFI_SUCCESS;
+
 	loader_str = split_load_options(li->LoadOptions, li->LoadOptionsSize,
 					&remaining, &remaining_size);
 


### PR DESCRIPTION
Windows bcdedit.exe creates boot entries where load options begin with "WINDOWS\0" (in 8-bit chars), followed by some Windows-specific data which is useless for shim. This data causes shim error "Failed to open \EFI\mypath\䥗䑎坏S".

Resolves: #370