### PR TITLE
Fix file system browser hang when enrolling MOK from disk

### DIFF
--- a/lib/simple_file.c
+++ b/lib/simple_file.c
@@ -170,7 +170,7 @@ simple_file_write_all(EFI_FILE *file, UINTN size, void *buffer)
 EFI_STATUS
 simple_volume_selector(CHAR16 **title, CHAR16 **selected, EFI_HANDLE *h)
 {
-	UINTN count, i;
+	UINTN count, i, j;
 	EFI_HANDLE *vol_handles = NULL;
 	EFI_STATUS efi_status;
 	CHAR16 **entries;
@@ -188,7 +188,7 @@ simple_volume_selector(CHAR16 **title, CHAR16 **selected, EFI_HANDLE *h)
 	if (!entries)
 		return EFI_OUT_OF_RESOURCES;
 
-	for (i = 0; i < count; i++) {
+	for (i = 0, j = 0; i < count; i++) {
 		char buf[4096];
 		UINTN size = sizeof(buf);
 		EFI_FILE_SYSTEM_INFO *fi = (void *)buf;
@@ -218,12 +218,12 @@ simple_volume_selector(CHAR16 **title, CHAR16 **selected, EFI_HANDLE *h)
 		if (!name || StrLen(name) == 0 || StrCmp(name, L" ") == 0)
 			name = DevicePathToStr(DevicePathFromHandle(vol_handles[i]));
 
-		entries[i] = AllocatePool((StrLen(name) + 2) * sizeof(CHAR16));
-		if (!entries[i])
+		entries[j] = AllocatePool((StrLen(name) + 2) * sizeof(CHAR16));
+		if (!entries[j])
 			break;
-		StrCpy(entries[i], name);
+		StrCpy(entries[j++], name);
 	}
-	entries[i] = NULL;
+	entries[j] = NULL;
 
 	val = console_select(title, entries, 0);
 

--- a/lib/simple_file.c
+++ b/lib/simple_file.c
@@ -184,7 +184,7 @@ simple_volume_selector(CHAR16 **title, CHAR16 **selected, EFI_HANDLE *h)
 	if (!count || !vol_handles)
 		return EFI_NOT_FOUND;
 
-	entries = AllocatePool(sizeof(CHAR16 *) * (count+1));
+	entries = AllocateZeroPool(sizeof(CHAR16 *) * (count+1));
 	if (!entries)
 		return EFI_OUT_OF_RESOURCES;
 

--- a/lib/simple_file.c
+++ b/lib/simple_file.c
@@ -208,10 +208,13 @@ simple_volume_selector(CHAR16 **title, CHAR16 **selected, EFI_HANDLE *h)
 
 		efi_status = root->GetInfo(root, &EFI_FILE_SYSTEM_INFO_GUID,
 					   &size, fi);
-		if (EFI_ERROR(efi_status))
-			continue;
+		/* If GetInfo fails, try to form a name from DevicePath. */
+		if (EFI_ERROR(efi_status)){
+			name = NULL;
+		} else {
+			name = fi->VolumeLabel;
+		}
 
-		name = fi->VolumeLabel;
 		if (!name || StrLen(name) == 0 || StrCmp(name, L" ") == 0)
 			name = DevicePathToStr(DevicePathFromHandle(vol_handles[i]));
 


### PR DESCRIPTION
The loop retrieving the SimpleFS volume labels and names may skip some volumes if either HandleProtocol or OpenVolume or GetInfo fails. Those skipped volumes would have uninitialized pointers to their names in the respective entries indices. This would lead to accessing random memory in console_select, because count_lines would not catch the holes with non-existing entries.

On affected platforms the result is a hang of the MokManager while trying to enroll a key from disk. The issue has been triggered on a TianoCore EDK2 UEFIPayload based firmware for x86 platforms with additional filesystem drivers: ExFAT, NTFS, EXT2 and EXT4.
    
