### PR TITLE
Improving the robustness of value retention for the variable second_stage

### DIFF
--- a/include/load-options.h
+++ b/include/load-options.h
@@ -12,7 +12,6 @@ EFI_STATUS generate_path_from_image_path(EFI_LOADED_IMAGE *li,
 
 EFI_STATUS parse_load_options(EFI_LOADED_IMAGE *li);
 
-extern CHAR16 *second_stage;
 extern void *load_options;
 extern UINT32 load_options_size;
 

--- a/shim.c
+++ b/shim.c
@@ -54,6 +54,8 @@ extern struct {
 
 #define EFI_IMAGE_SECURITY_DATABASE_GUID { 0xd719b2cb, 0x3d3a, 0x4596, { 0xa3, 0xbc, 0xda, 0xd0, 0x0e, 0x67, 0x65, 0x6f }}
 
+static CHAR16 *second_stage;
+
 typedef enum {
 	DATA_FOUND,
 	DATA_NOT_FOUND,


### PR DESCRIPTION
in function: shim_init(void)
in function: EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
second_stage is set to \\grubx64.efi
in the further course of time:
in function: efi_status = init_grub(image_handle);
EFI_STATUS init_grub(EFI_HANDLE image_handle)
second_stage variable - no longer has any value !!! the value \\grubx64.efi has been lost
see attached screen foto:
![IMG_5120](https://github.com/rhboot/shim/assets/51372456/fbc2faf6-8310-4d2c-8241-abf9b83f8179)
In order to improve the robustness of value retention for the variable second_stage we have done following changes:
in /shim/include/load-options.h
removed line with: extern CHAR16 *second_stage;
in /shim/shim.c
we set new variable just after the #define OID_EKU_MODSIGN "1.3.6.1.4.1.2312.16.1.2"
static CHAR16 *second_stage;
After making this improvement, I didn't get an error message when booting anymore.

