### PR TITLE
Improving the robustness of value retention for the variable second_stage

### DIFF
--- a/load-options.c
+++ b/load-options.c
@@ -447,7 +447,9 @@ parse_load_options(EFI_LOADED_IMAGE *li)
 
 	/*
 	 * Set up the name of the alternative loader and the LoadOptions for
-	 * the loader
+	 * the loader. But before that check the first char of loader_str
+	 * for non printable character. If this is a case do not set up 
+	 * alternative loader
 	 */
 	if (loader_str && isprint(loader_str[0])) {
 		second_stage = loader_str;

--- a/load-options.c
+++ b/load-options.c
@@ -449,7 +449,7 @@ parse_load_options(EFI_LOADED_IMAGE *li)
 	 * Set up the name of the alternative loader and the LoadOptions for
 	 * the loader
 	 */
-	if (loader_str) {
+	if (loader_str && isprint(loader_str[0])) {
 		second_stage = loader_str;
 		load_options = remaining;
 		load_options_size = remaining_size;


### PR DESCRIPTION
in function: shim_init(void)
in function: EFI_STATUS set_second_stage (EFI_HANDLE image_handle)
second_stage is set to \grubx64.efi
in the further course of time:
in function: efi_status = init_grub(image_handle);
EFI_STATUS init_grub(EFI_HANDLE image_handle)
second_stage variable - no longer has any value !!! the value \grubx64.efi has been lost
see attached screen foto:
![IMG_5120](https://github.com/rhboot/shim/assets/51372456/a0fff312-0343-4566-9000-d3b7fa150a25)
We have localized this problem:
in the file load-options.c in function parse_load_options(EFI_LOADED_IMAGE *li) the variable loader_str was initialized as CHAR16 *loader_str = NULL;
In the same file line Nr 445 the variable loader_str has received a non-printable ascii character from the function split_load_options(). This means that the variable does not have a NULL value anymore but have got the value "non-printable ascii character". After further check (line 454): if (loader_str) if variable has still NULL value the result was positive (loader_str is not NULL and it has a value) and the variable second_stage (\grubx64.efi) has been overwritten by a non-printable ascii character, as you can see on the screen-foto.
To improve this situation we have introduced the additional check of the first character of the variable loader_str in order to be sure, that at least first character is not a non-printable ascii character:
Line 454 if (loader_str && isprint(loader_str[0])). For this purpose we use standard function isprint(). This function returns true if the character is printable ascii character. 
In this way we have solved the problem with non-printable ascii characters and overwriting the originally set value \grubx64.efi for second_stage through the non printable char. I think this improvement will be useful for all users of Shim boot-loader because this situation with non printable characters, as we see, can happen.

