### PR TITLE
shim.c: add the marco switch to allow users to choose whether the next boot loader signature failure is enforced or not when secure boot is enabled.

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -624,7 +624,11 @@ verify_buffer_authenticode (char *data, int datasize,
 
 	if (context->SecDir->Size == 0) {
 		dprint(L"No signatures found\n");
+#ifdef ALLOW_SECURE_BOOT_SIGNATURE_VERIFY_ERROR
+		return EFI_SUCCESS;
+#else
 		return EFI_SECURITY_VIOLATION;
+#endif
 	}
 
 	if (context->SecDir->Size >= size) {
@@ -689,7 +693,11 @@ verify_buffer_authenticode (char *data, int datasize,
 		PrintErrors();
 		ClearErrors();
 		crypterr(EFI_SECURITY_VIOLATION);
+#ifdef ALLOW_SECURE_BOOT_SIGNATURE_VERIFY_ERROR
+		return EFI_SUCCESS;
+#else
 		ret_efi_status = EFI_SECURITY_VIOLATION;
+#endif
 	}
 	drain_openssl_errors();
 	return ret_efi_status;


### PR DESCRIPTION
Similar to the kernel module forced signature verification configuration (CONFIG_MODULE_SIG_FORCE), we can introduce a switch at compile time to each component of the secure boot (including shim) to allow users to choose whether to force signature verification and intercept the next-level bootloader that fails the signature verification(unsigned or signed incorrectly, etc.) according to their own needs. Of course, the default is still forced signature verification and interception. If there are only alarms rather than forced interception, you can add the `CFLAGS +=-DALLOW_SECURE_BOOT_SIGNATURE_VERIFY_ERROR` compilation option to the Makefile to control it.

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>