### PR TITLE
shim: don't set second_stage to the empty string

### DIFF
--- a/load-options.c
+++ b/load-options.c
@@ -447,10 +447,12 @@ parse_load_options(EFI_LOADED_IMAGE *li)
 
 	/*
 	 * Set up the name of the alternative loader and the LoadOptions for
-	 * the loader
+	 * the loader if it's not the empty string.
 	 */
 	if (loader_str) {
-		second_stage = loader_str;
+		if (*loader_str) {
+			second_stage = loader_str;
+		}
 		load_options = remaining;
 		load_options_size = remaining_size;
 	}


### PR DESCRIPTION
When LoadOptions is either L" " or L"shim.efi ", parse_load_options sets second_stage to the empty string. This is unlikely to be what is intended, and typically leads to a non-obvious failure mode.

The failure happens because parse_load_options's call to split_load_options (after eating shim's own filename, if present) returns the empty string. Since init_grub typically passes second_stage to start_image, this causes read_image to concatenate the empty string onto the directory name. This means PathName refers to the directory, not the path to a pe image. Then load_image successfully opens a handle on the directory and reads "data" from it. It only eventually fails when handle_image calls read_header which finds that this data isn't in fact a pe header, reporting "Invalid image".

This scenario has been seen when shim is loaded via rEFInd 0.11.5, which sets LoadOptions to the name of the shim program followed by a space character.

Instead, modify parse_load_options to leave second_stage set to its default value rather than the empty string.