### PR TITLE
Provide better error message when MokManager is not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,10 @@ CFLAGS += -DENABLE_SHIM_CERT
 else
 TARGETS += $(MMNAME) $(FBNAME)
 endif
-OBJS	= shim.o globals.o mok.o netboot.o cert.o replacements.o tpm.o version.o errlog.o sbat.o sbat_data.o sbat_var.o pe.o pe-relocate.o httpboot.o csv.o load-options.o
+OBJS	= shim.o globals.o mok.o netboot.o cert.o dp.o replacements.o tpm.o version.o errlog.o sbat.o sbat_data.o sbat_var.o pe.o pe-relocate.o httpboot.o csv.o load-options.o
 KEYS	= shim_cert.h ocsp.* ca.* shim.crt shim.csr shim.p12 shim.pem shim.key shim.cer
-ORIG_SOURCES	= shim.c globals.c mok.c netboot.c replacements.c tpm.c errlog.c sbat.c pe.c pe-relocate.c httpboot.c shim.h version.h $(wildcard include/*.h) cert.S sbat_var.S
-MOK_OBJS = MokManager.o PasswordCrypt.o crypt_blowfish.o errlog.o sbat_data.o globals.o
+ORIG_SOURCES	= shim.c globals.c mok.c netboot.c dp.c replacements.c tpm.c errlog.c sbat.c pe.c pe-relocate.c httpboot.c shim.h version.h $(wildcard include/*.h) cert.S sbat_var.S
+MOK_OBJS = MokManager.o PasswordCrypt.o crypt_blowfish.o errlog.o sbat_data.o globals.o dp.o
 ORIG_MOK_SOURCES = MokManager.c PasswordCrypt.c crypt_blowfish.c shim.h $(wildcard include/*.h)
 FALLBACK_OBJS = fallback.o tpm.o errlog.o sbat_data.o globals.o
 ORIG_FALLBACK_SRCS = fallback.c

--- a/dp.c
+++ b/dp.c
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/*
+ * dp.c - device path helpers
+ * Copyright Peter Jones <pjones@redhat.com>
+ */
+
+#include "shim.h"
+
+int
+is_removable_media_path(EFI_LOADED_IMAGE *li)
+{
+	unsigned int pathlen = 0;
+	CHAR16 *bootpath = NULL;
+	int ret = 0;
+
+	bootpath = DevicePathToStr(li->FilePath);
+
+	/* Check the beginning of the string and the end, to avoid
+	 * caring about which arch this is. */
+	/* I really don't know why, but sometimes bootpath gives us
+	 * L"\\EFI\\BOOT\\/BOOTX64.EFI".  So just handle that here...
+	 */
+	if (StrnCaseCmp(bootpath, L"\\EFI\\BOOT\\BOOT", 14) &&
+			StrnCaseCmp(bootpath, L"\\EFI\\BOOT\\/BOOT", 15) &&
+			StrnCaseCmp(bootpath, L"EFI\\BOOT\\BOOT", 13) &&
+			StrnCaseCmp(bootpath, L"EFI\\BOOT\\/BOOT", 14))
+		goto error;
+
+	pathlen = StrLen(bootpath);
+	if (pathlen < 5 || StrCaseCmp(bootpath + pathlen - 4, L".EFI"))
+		goto error;
+
+	ret = 1;
+
+error:
+	if (bootpath)
+		FreePool(bootpath);
+
+	return ret;
+}
+
+
+// vim:fenc=utf-8:tw=75:noet

--- a/include/dp.h
+++ b/include/dp.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/*
+ * dp.h - device path helper functions
+ * Copyright Peter Jones <pjones@redhat.com>
+ */
+
+#ifndef DP_H_
+#define DP_H_
+
+int
+is_removable_media_path(EFI_LOADED_IMAGE *li);
+
+#endif /* !DP_H_ */
+// vim:fenc=utf-8:tw=75:noet

--- a/shim.c
+++ b/shim.c
@@ -779,39 +779,6 @@ verify_buffer (char *data, int datasize,
 }
 
 static int
-is_removable_media_path(EFI_LOADED_IMAGE *li)
-{
-	unsigned int pathlen = 0;
-	CHAR16 *bootpath = NULL;
-	int ret = 0;
-
-	bootpath = DevicePathToStr(li->FilePath);
-
-	/* Check the beginning of the string and the end, to avoid
-	 * caring about which arch this is. */
-	/* I really don't know why, but sometimes bootpath gives us
-	 * L"\\EFI\\BOOT\\/BOOTX64.EFI".  So just handle that here...
-	 */
-	if (StrnCaseCmp(bootpath, L"\\EFI\\BOOT\\BOOT", 14) &&
-			StrnCaseCmp(bootpath, L"\\EFI\\BOOT\\/BOOT", 15) &&
-			StrnCaseCmp(bootpath, L"EFI\\BOOT\\BOOT", 13) &&
-			StrnCaseCmp(bootpath, L"EFI\\BOOT\\/BOOT", 14))
-		goto error;
-
-	pathlen = StrLen(bootpath);
-	if (pathlen < 5 || StrCaseCmp(bootpath + pathlen - 4, L".EFI"))
-		goto error;
-
-	ret = 1;
-
-error:
-	if (bootpath)
-		FreePool(bootpath);
-
-	return ret;
-}
-
-static int
 should_use_fallback(EFI_HANDLE image_handle)
 {
 	EFI_LOADED_IMAGE *li;

--- a/shim.c
+++ b/shim.c
@@ -1154,7 +1154,7 @@ EFI_STATUS read_image(EFI_HANDLE image_handle, CHAR16 *ImagePath,
 		efi_status = load_image(shim_li, data, datasize, *PathName);
 		if (EFI_ERROR(efi_status)) {
 			perror(L"Failed to load image %s: %r\n",
-			       PathName, efi_status);
+			       *PathName, efi_status);
 			PrintErrors();
 			ClearErrors();
 			return efi_status;

--- a/shim.h
+++ b/shim.h
@@ -163,6 +163,7 @@
 #include "include/configtable.h"
 #include "include/console.h"
 #include "include/crypt_blowfish.h"
+#include "include/dp.h"
 #include "include/efiauthenticated.h"
 #include "include/errors.h"
 #include "include/execute.h"


### PR DESCRIPTION
If MokManager has to be entered but system is booting on disk on `EFI/BOOT/BOOTx.EFI` entry, MokManager cannot be found because it's not in that directory.
This indicates an issue with the BootOrder or the UEFI firmware is just not taking BootOrder into account (seen on Lenovo ThinkPad P1 Gen 6 and VMWare).
This patch prints a related message and reboots after 10 seconds.
    
### Reproducer

1. Import a certificate using mokutil
2. Tell UEFI to boot on BOOTX64.EFI entry on next boot
    
### Result without the patch (with verbosity enabled)

~~~
mok.c:1045:import_mok_state() checking mok request
shim.c:866:load_image() attempting to load \EFI\BOOT\mmx64.efi
Failed to open \EFI\BOOT\mmx64.efi - Not Found
Failed to load image 貘給: Not Found
shim.c:888 load_image() Failed to open \EFI\BOOT\mmx64.efi - Not Found
shim.c:1115 read_image() Failed to load image 貘給: Not Found
Failed to start MokManager: Not Found
mok.c:1047:import_mok_state() mok returned Not Found
Something has gone seriously wrong: import_mok_state() failed: Not Found
~~~

### Result with the patch

Box with title "Could not find MokManager" and message "Boot Order must be misconfigured or not honored by the UEFI firmware.", then system rebooted after 10 seconds (in hope the BootOrder will be good next time).
