### PR TITLE
Improve shortcut performance when comparing two boolean expressions

### DIFF
--- a/sbat.c
+++ b/sbat.c
@@ -537,9 +537,9 @@ set_sbat_uefi_variable(char *sbat_var_automatic, char *sbat_var_latest)
 	 */
 	if (EFI_ERROR(efi_status)) {
 		dprint(L"SBAT read failed %r\n", efi_status);
-	} else if (preserve_sbat_uefi_variable(sbat, sbatsize, attributes,
-	                                       sbat_var_candidate) &&
-	           !reset_sbat) {
+	} else if (!reset_sbat &&
+		   preserve_sbat_uefi_variable(sbat, sbatsize, attributes,
+	                                       sbat_var_candidate)) {
 		dprint(L"preserving %s variable it is %d bytes, attributes are 0x%08x\n",
 		       SBAT_VAR_NAME, sbatsize, attributes);
 		FreePool(sbat);


### PR DESCRIPTION
In original sbat.c:
```
else if (preserve_sbat_uefi_variable(sbat, sbatsize, attributes,
	                             sbat_var_candidate) &&
	 !reset_sbat) {
```

The time omplexity of preserve_sbat_uefi_variable() is higher than reset_sbat. Maybe we could swap both of them to calculate reset_sbat first. Such that the shortcut performance can be improved.