### PR TITLE
Update gnu-efi submodule for EFI_HTTP_ERROR

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "gnu-efi"]
 	path = gnu-efi
 	url = https://github.com/rhboot/gnu-efi.git
-	branch = shim-15.8
+	branch = shim-15.9


### PR DESCRIPTION
This updates our gnu-efi module to include the UEFI 2.10 error codes.