### PR TITLE
Fix the issue that the gBS->LoadImage pointer was empty.

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1746,11 +1746,12 @@ shim_fini(void)
 	uninstall_shim_protocols();
 
 	if (secure_mode()) {
-
-		/*
-		 * Remove our hooks from system services.
-		 */
-		unhook_system_services();
+		if (vendor_authorized_size || vendor_deauthorized_size) {
+			/*
+			* Remove our hooks from system services.
+			*/
+			unhook_system_services();
+		}
 	}
 
 	unhook_exit();


### PR DESCRIPTION
The interface shouldn't be replaced at the shim_fini
 stage When the vendor certificate doesn't exist.