### PR TITLE
Generate SbatLevel Metadata from SbatLevel_Variable.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Make.local
 /fuzz-*
 !/fuzz-*.c
 /generate_sbat_var_defs
+/generated_sbat_var_defs.h
 /leak-*
 /post-process-pe
 /random.bin

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Make.local
 /crash-*
 /fuzz-*
 !/fuzz-*.c
+/generate_sbat_var_defs
 /leak-*
 /post-process-pe
 /random.bin

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ CFLAGS += -DENABLE_SHIM_CERT
 else
 TARGETS += $(MMNAME) $(FBNAME)
 endif
+# This is temporary and will go away soon
+TARGETS += generate_sbat_var_defs
 OBJS	= shim.o globals.o mok.o netboot.o cert.o dp.o replacements.o tpm.o version.o errlog.o sbat.o sbat_data.o sbat_var.o pe.o pe-relocate.o httpboot.o csv.o load-options.o
 KEYS	= shim_cert.h ocsp.* ca.* shim.crt shim.csr shim.p12 shim.pem shim.key shim.cer
 ORIG_SOURCES	= shim.c globals.c mok.c netboot.c dp.c replacements.c tpm.c errlog.c sbat.c pe.c pe-relocate.c httpboot.c shim.h version.h $(wildcard include/*.h) cert.S sbat_var.S
@@ -186,6 +188,9 @@ lib/lib.a: | $(TOPDIR)/lib/Makefile $(wildcard $(TOPDIR)/include/*.[ch])
 	$(MAKE) VPATH=$(TOPDIR)/lib TOPDIR=$(TOPDIR) -C lib -f $(TOPDIR)/lib/Makefile $(IGNORE_COMPILER_ERRORS)
 
 post-process-pe : $(TOPDIR)/post-process-pe.c
+	$(HOSTCC) -std=gnu11 -Og -g3 -Wall -Wextra -Wno-missing-field-initializers -Werror -o $@ $<
+
+generate_sbat_var_defs: $(TOPDIR)/generate_sbat_var_defs.c
 	$(HOSTCC) -std=gnu11 -Og -g3 -Wall -Wextra -Wno-missing-field-initializers -Werror -o $@ $<
 
 buildid : $(TOPDIR)/buildid.c
@@ -356,6 +361,7 @@ clean-lib-objs:
 clean-shim-objs:
 	@rm -rvf $(TARGET) *.o $(SHIM_OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb $(BOOTCSVNAME)
 	@rm -vf *.debug *.so *.efi *.efi.* *.tar.* version.c buildid post-process-pe compile_commands.json
+	@rm -vf generate_sbat_var_defs
 	@rm -vf Cryptlib/*.[oa] Cryptlib/*/*.[oa]
 	@if [ -d .git ] ; then git clean -f -d -e 'Cryptlib/OpenSSL/*'; fi
 

--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,6 @@ CFLAGS += -DENABLE_SHIM_CERT
 else
 TARGETS += $(MMNAME) $(FBNAME)
 endif
-# This is temporary and will go away soon
-TARGETS += generate_sbat_var_defs
 OBJS	= shim.o globals.o mok.o netboot.o cert.o dp.o replacements.o tpm.o version.o errlog.o sbat.o sbat_data.o sbat_var.o pe.o pe-relocate.o httpboot.o csv.o load-options.o
 KEYS	= shim_cert.h ocsp.* ca.* shim.crt shim.csr shim.p12 shim.pem shim.key shim.cer
 ORIG_SOURCES	= shim.c globals.c mok.c netboot.c dp.c replacements.c tpm.c errlog.c sbat.c pe.c pe-relocate.c httpboot.c shim.h version.h $(wildcard include/*.h) cert.S sbat_var.S
@@ -102,6 +100,7 @@ shim.crt:
 shim.cer: shim.crt
 	$(OPENSSL) x509 -outform der -in $< -out $@
 
+
 .NOTPARALLEL: shim_cert.h
 shim_cert.h: shim.cer
 	echo "static UINT8 shim_cert[] __attribute__((__unused__)) = {" > $@
@@ -123,7 +122,11 @@ shim.o: $(SOURCES)
 ifneq ($(origin ENABLE_SHIM_CERT),undefined)
 shim.o: shim_cert.h
 endif
+# Both of these need to be here so that when TOPDIR is unset, make isn't trying
+# to match against ./sbat_var.S, which isn't a target it will ever try to build.
+$(TOPDIR)/sbat_var.S sbat_var.S: generated_sbat_var_defs.h
 shim.o: $(wildcard $(TOPDIR)/*.h)
+
 
 sbat.%.csv : data/sbat.%.csv
 	$(DOS2UNIX) $(D2UFLAGS) $< $@
@@ -192,6 +195,10 @@ post-process-pe : $(TOPDIR)/post-process-pe.c
 
 generate_sbat_var_defs: $(TOPDIR)/generate_sbat_var_defs.c
 	$(HOSTCC) -std=gnu11 -Og -g3 -Wall -Wextra -Wno-missing-field-initializers -Werror -o $@ $<
+
+.NOTPARALLEL: generated_sbat_var_defs.h
+generated_sbat_var_defs.h: generate_sbat_var_defs
+	./generate_sbat_var_defs $(TOPDIR) > $@
 
 buildid : $(TOPDIR)/buildid.c
 	$(HOSTCC) -I/usr/include -Og -g3 -Wall -Werror -Wextra -o $@ $< -lelf
@@ -317,7 +324,7 @@ fuzz fuzz-clean fuzz-coverage fuzz-lto :
 		EFI_INCLUDES="$(EFI_INCLUDES)" \
 		fuzz-clean $@
 
-test test-clean test-coverage test-lto :
+test test-clean test-coverage test-lto : generated_sbat_var_defs.h
 	@make -f $(TOPDIR)/include/test.mk \
 		COMPILER="$(COMPILER)" \
 		CROSS_COMPILE="$(CROSS_COMPILE)" \
@@ -361,7 +368,7 @@ clean-lib-objs:
 clean-shim-objs:
 	@rm -rvf $(TARGET) *.o $(SHIM_OBJS) $(MOK_OBJS) $(FALLBACK_OBJS) $(KEYS) certdb $(BOOTCSVNAME)
 	@rm -vf *.debug *.so *.efi *.efi.* *.tar.* version.c buildid post-process-pe compile_commands.json
-	@rm -vf generate_sbat_var_defs
+	@rm -vf generate_sbat_var_defs generated_sbat_var_defs.h
 	@rm -vf Cryptlib/*.[oa] Cryptlib/*/*.[oa]
 	@if [ -d .git ] ; then git clean -f -d -e 'Cryptlib/OpenSSL/*'; fi
 

--- a/SbatLevel_Variable.txt
+++ b/SbatLevel_Variable.txt
@@ -97,6 +97,18 @@ shim,4
 grub,3
 grub.debian,4
 
+
+Revocations for:
+ - January 2024 shim CVEs
+ - October 2023 grub CVEs
+ - Debian/Ubuntu (peimage) CVE-2024-2312
+
+sbat,1,2024040900
+shim,4
+grub,4
+grub.peimage,2
+
+
 Since http boot shim CVE is considerably more serious than then GRUB
 ntfs CVEs shim is delivering the shim revocation without the updated
 GRUB revocation as a latest payload.

--- a/SbatLevel_Variable.txt
+++ b/SbatLevel_Variable.txt
@@ -1,6 +1,15 @@
-In order to apply SBAT based revocations on systems that will never
-run shim, code running in boot services context needs to set the
-following variable:
+This file is the single source for SbatLevel revocations the format
+follows the variable payload and should not have any leading or
+trailing whitespace on the same line.
+
+Short descriptions of the revocations as well as CVE assignments (when
+available) should be provided when an entry is added.
+
+On systems that run shim, shim will manage these revocations. Sytems
+that never run shim, primarily Windows, but this applies to any OS
+that supports UEFI Secure Boot under the UEFI CA without shim can
+apply SBAT based revocations by setting the following variable
+from code running in boot services context.
 
 Name: SbatLevel
 Attributes: (EFI_VARIABLE_NON_VOLATILE | EFI_VARIABLE_BOOTSERVICE_ACCESS)

--- a/generate_sbat_var_defs.c
+++ b/generate_sbat_var_defs.c
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+/*
+ * This generates the header files that produce the actual revocation
+ * string payload. On the one hand this grabs the defintions from the
+ * human readable SbatLevel_Variable.txt file which is nice. On the other
+ * hand it's one off c code.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct sbat_revocation sbat_revocation;
+
+struct sbat_revocation {
+	int date;
+	char *revocations;
+	sbat_revocation *next;
+};
+
+static sbat_revocation *revlisthead;
+
+int
+readfile(char *SbatLevel_Variable)
+{
+	FILE *varfilep;
+	char line[1024];
+	int date;
+
+	int revocationsp = 0;
+
+	sbat_revocation *revlistlast = NULL;
+	sbat_revocation *revlistentry = NULL;
+
+	revlisthead = NULL;
+
+	varfilep = fopen(SbatLevel_Variable, "r");
+	if (varfilep == NULL)
+		return -1;
+
+	while (fgets(line, sizeof(line), varfilep) != NULL) {
+		if (sscanf(line, "sbat,1,%d\n", &date) && strlen(line) == 18) {
+			revlistentry =
+				(sbat_revocation *)malloc(sizeof(sbat_revocation));
+			if (revlistentry == NULL)
+				return -1;
+			if (revlisthead == NULL)
+				revlisthead = revlistentry;
+			else
+				revlistlast->next = revlistentry;
+
+			revlistlast = revlistentry;
+
+			revlistentry->date = date;
+			while (line[0] != '\n' &&
+			       fgets(line, sizeof(line), varfilep) != NULL) {
+					revlistentry->revocations =
+						(char *)realloc(revlistentry->revocations,
+								 revocationsp +
+								 strlen(line) + 1);
+					if (revlistentry->revocations == NULL)
+						return -1;
+					if (strlen(line) > 1) {
+						line[strlen(line) -1] = 0;
+						sprintf(revlistentry->revocations
+							+ revocationsp, "%s\\n", line);
+					revocationsp = revocationsp + strlen(line) + 2;
+					}
+			}
+			revocationsp = 0;
+
+		}
+	}
+
+	return 1;
+}
+
+int
+writefile()
+{
+	int epochfound = 0;
+	int epochdate = 2021030218;
+	int latestdate = 0;
+
+	sbat_revocation *revlistentry;
+	sbat_revocation *latest_revlistentry = NULL;
+
+	revlistentry = revlisthead;
+
+	while (revlistentry != NULL) {
+		if (revlistentry->date == epochdate) {
+			printf("#ifndef GEN_SBAT_VAR_DEFS_H_\n"
+			       "#define GEN_SBAT_VAR_DEFS_H_\n"
+			       "#ifndef ENABLE_SHIM_DEVEL\n\n"
+			       "#ifndef SBAT_AUTOMATIC_DATE\n"
+			       "#define SBAT_AUTOMATIC_DATE 2023012900\n"
+			       "#endif /* SBAT_AUTOMATIC_DATE */\n"
+			       "#if SBAT_AUTOMATIC_DATE == %d\n"
+			       "#define SBAT_VAR_AUTOMATIC_REVOCATIONS\n",
+			       revlistentry->date);
+			epochfound = 1;
+		} else if (epochfound == 1) {
+			printf("#elif SBAT_AUTOMATIC_DATE == %d\n"
+			       "#define SBAT_VAR_AUTOMATIC_REVOCATIONS \"%s\"\n",
+			       revlistentry->date,
+			       revlistentry->revocations);
+		}
+		if (revlistentry->date > latestdate) {
+			latest_revlistentry = revlistentry;
+			latestdate = revlistentry->date;
+		}
+		revlistentry = revlistentry->next;
+	}
+
+	if (epochfound == 0 || !latest_revlistentry)
+		return -1;
+
+	printf("#else\n"
+	       "#error \"Unknown SBAT_AUTOMATIC_DATE\"\n"
+	       "#endif /* SBAT_AUTOMATIC_DATE == */\n\n"
+	       "#define SBAT_VAR_AUTOMATIC_DATE QUOTEVAL(SBAT_AUTOMATIC_DATE)\n"
+	       "#define SBAT_VAR_AUTOMATIC \\\n"
+               "	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_AUTOMATIC_DATE \"\\n\" \\\n"
+               "	SBAT_VAR_AUTOMATIC_REVOCATIONS\n\n");
+
+	printf("#define SBAT_VAR_LATEST_DATE \"%d\"\n"
+	       "#define SBAT_VAR_LATEST_REVOCATIONS \"%s\"\n",
+	       latest_revlistentry->date,
+	       latest_revlistentry->revocations);
+
+	printf("#define SBAT_VAR_LATEST \\\n"
+               "	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_LATEST_DATE \"\\n\" \\\n"
+               "	SBAT_VAR_LATEST_REVOCATIONS\n\n"
+	       "#endif /* !ENABLE_SHIM_DEVEL */\n"
+	       "#endif /* !GEN_SBAT_VAR_DEFS_H_ */\n");
+
+	return 0;
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	char SbatLevel_Variable[2048];
+
+	if (argc == 2)
+		snprintf(SbatLevel_Variable, 2048, "%s/SbatLevel_Variable.txt", argv[1]);
+	else
+		snprintf(SbatLevel_Variable, 2048, "SbatLevel_Variable.txt");
+
+	if (readfile(SbatLevel_Variable))
+		return writefile();
+	else
+		return -1;
+}

--- a/include/sbat_var_defs.h
+++ b/include/sbat_var_defs.h
@@ -7,7 +7,9 @@
 #define QUOTE(s) #s
 
 /*
- * This is the entry for the sbat data format
+ * SbatLevel Epoch and SHIM_DEVEL definitions are here
+ * Actual revocations are now soley defined in
+ * SbatLevel_Variable.txt
  */
 #define SBAT_VAR_SIG "sbat,"
 #define SBAT_VAR_VERSION "1,"
@@ -22,51 +24,10 @@
 
 #define SBAT_VAR_LATEST_DATE "2022050100"
 #define SBAT_VAR_LATEST_REVOCATIONS "component,2\nothercomponent,2\n"
-#define SBAT_VAR_LATEST \
-	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_LATEST_DATE "\n" \
-	SBAT_VAR_LATEST_REVOCATIONS
-#else /* !ENABLE_SHIM_DEVEL */
 
-/*
- * Some distros may want to apply revocations from 2022052400
- * or 2022111500 automatically. They can be selected by setting
- * SBAT_AUTOMATIC_DATE=<datestamp> at build time. Otherwise the
- * default is to apply the second to most recent revocations
- * automatically. Distros that need to manage automatic updates
- * externally from shim can choose the epoch 2021030218 emtpy
- * revocations.
- */
-#ifndef SBAT_AUTOMATIC_DATE
-#define SBAT_AUTOMATIC_DATE 2023012900
-#endif /* SBAT_AUTOMATIC_DATE */
-#if SBAT_AUTOMATIC_DATE == 2021030218
-#define SBAT_VAR_AUTOMATIC_REVOCATIONS
-#elif SBAT_AUTOMATIC_DATE == 2022052400
-#define SBAT_VAR_AUTOMATIC_REVOCATIONS "grub,2\n"
-#elif SBAT_AUTOMATIC_DATE == 2022111500
-#define SBAT_VAR_AUTOMATIC_REVOCATIONS "shim,2\ngrub,3\n"
-#elif SBAT_AUTOMATIC_DATE == 2023012900
-#define SBAT_VAR_AUTOMATIC_REVOCATIONS "shim,2\ngrub,3\ngrub.debian,4\n"
-#elif SBAT_AUTOMATIC_DATE == 2024010900
-#define SBAT_VAR_AUTOMATIC_REVOCATIONS "shim,4\ngrub,3\ngrub.debian,4\n"
-#else
-#error "Unknown SBAT_AUTOMATIC_DATE"
-#endif /* SBAT_AUTOMATIC_DATE == */
-#define SBAT_VAR_AUTOMATIC_DATE QUOTEVAL(SBAT_AUTOMATIC_DATE)
-#define SBAT_VAR_AUTOMATIC \
-	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_AUTOMATIC_DATE "\n" \
-	SBAT_VAR_AUTOMATIC_REVOCATIONS
-
-/*
- * Revocations for:
- * - January 2024 shim CVEs
- * - October 2023 grub CVEs
- * - Debian/Ubuntu (peimage) CVE-2024-2312
- */
-#define SBAT_VAR_LATEST_DATE "2024040900"
-#define SBAT_VAR_LATEST_REVOCATIONS "shim,4\ngrub,4\ngrub.peimage,2\n"
 #define SBAT_VAR_LATEST \
 	SBAT_VAR_SIG SBAT_VAR_VERSION SBAT_VAR_LATEST_DATE "\n" \
 	SBAT_VAR_LATEST_REVOCATIONS
 #endif /* ENABLE_SHIM_DEVEL */
+
 #endif /* !SBAT_VAR_DEFS_H_ */

--- a/sbat_var.S
+++ b/sbat_var.S
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 #include "include/sbat_var_defs.h"
+#include "generated_sbat_var_defs.h"
 
 	.section .sbatlevel, "a", %progbits
 	.balignl 4, 0

--- a/test-sbat.c
+++ b/test-sbat.c
@@ -8,6 +8,7 @@
 #include "sbat_var_defs.h"
 #endif
 #include "shim.h"
+#include "generated_sbat_var_defs.h"
 
 #include <stdio.h>
 


### PR DESCRIPTION
This makes SbatLevel_Variable.txt the single source of truth for SbatLevel metadata and generates the header file from it.