### PR TITLE
test-mok-mirror: minor bug fix

### DIFF
--- a/include/mock-variables.h
+++ b/include/mock-variables.h
@@ -117,6 +117,7 @@ void mock_reset_config_table(void);
 void mock_finalize_vars_and_configs(void);
 void mock_set_usage_limits(list_t *limit_list,
 			   struct mock_variable_limits *limits);
+void mock_set_default_usage_limits(void);
 
 typedef enum {
 	NONE = 0,

--- a/test-mok-mirror.c
+++ b/test-mok-mirror.c
@@ -633,6 +633,8 @@ test_mok_mirror_setvar_out_of_resources(void)
 			      test_mok_config_table,
 			      EFI_OUT_OF_RESOURCES);
 
+	mock_set_default_usage_limits();
+
 	mock_set_variable_post_hook = NULL;
 	mock_get_variable_post_hook = NULL;
 	return ret;


### PR DESCRIPTION
In 70366a286552760863bacb521fb00c654586b494, I introduced a test case for test-mok-mirror to test the behavior when SetVariable() gives EFI_OUT_OF_RESOURCES.  Unfortunately this includes a memory error in its cleanup functions:

==1972634== Invalid read of size 8
==1972634==    at 0x4032F3: mock_sv_adjust_usage_data (mock-variables.c:468)
==1972634==    by 0x40387B: mock_delete_variable (mock-variables.c:541)
==1972634==    by 0x4014E8: mock_reset_variables (mock-variables.c:1353)
==1972634==    by 0x401348: mock_finalize_vars_and_configs (mock-variables.c:1405)
==1972634==    by 0x401731: main (test-mok-mirror.c:688)
==1972634==  Address 0x1ffeffc4f8 is on thread 1's stack
==1972634==  6784 bytes below stack pointer

This is caused because the test data uses a linked-list data structure in an array in the test data, and we try to iterate the list to free the data, but of course the list pointers aren't initialized because it's an array.

Whoops.

This patch makes it so we don't try to clean up that list, because we don't need to.