### PR TITLE
Ignore a minor clang-tidy nit

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -1826,7 +1826,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 		L"shim_init() failed",
 		L"import of SBAT data failed",
 		L"SBAT self-check failed",
-		SBAT_VAR_NAME L" UEFI variable setting failed",
+		SBAT_VAR_NAME L" UEFI variable setting failed", // NOLINT(bugprone-suspicious-missing-comma)
 		NULL
 	};
 	enum {


### PR DESCRIPTION
This just turns off the clang-tidy warning about our SBAT_VAR_NAME string compositing in the error message list in efi_main(), as it's the only warning in the whole file and it's bugging me.