### PR TITLE
Save the debug and error logs in mok-variables

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -175,13 +175,18 @@
 #define BUILD_BUG_ON_MSG(cond, msg) compiletime_assert(!(cond), msg)
 #endif
 
-#ifndef ALIGN
+#ifndef __ALIGN
 #define __ALIGN_MASK(x, mask)   (((x) + (mask)) & ~(mask))
 #define __ALIGN(x, a)           __ALIGN_MASK(x, (typeof(x))(a) - 1)
+#endif
+#ifndef ALIGN
 #define ALIGN(x, a)             __ALIGN((x), (a))
 #endif
 #ifndef ALIGN_DOWN
 #define ALIGN_DOWN(x, a)        __ALIGN((x) - ((a) - 1), (a))
+#endif
+#ifndef ALIGN_UP
+#define ALIGN_UP(addr, align) (((addr) + (typeof (addr)) (align) - 1) & ~((typeof (addr)) (align) - 1))
 #endif
 
 #define MIN(a, b) ({(a) < (b) ? (a) : (b);})

--- a/include/console.h
+++ b/include/console.h
@@ -98,6 +98,7 @@ extern UINT32 verbose;
 #ifndef SHIM_UNIT_TEST
 #define dprint_(fmt, ...) ({							\
 		UINTN __dprint_ret = 0;						\
+		log_debug_print((fmt), ##__VA_ARGS__);				\
 		if (verbose)							\
 			__dprint_ret = console_print((fmt), ##__VA_ARGS__);	\
 		__dprint_ret;							\

--- a/include/errlog.h
+++ b/include/errlog.h
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/*
+ * errlog.h - error logging utilities
+ * Copyright Peter Jones <pjones@redhat.com>
+ */
+
+#ifndef ERRLOG_H_
+#define ERRLOG_H_
+
+extern EFI_STATUS EFIAPI LogError_(const char *file, int line, const char *func,
+                                   const CHAR16 *fmt, ...);
+extern EFI_STATUS EFIAPI VLogError(const char *file, int line, const char *func,
+                                   const CHAR16 *fmt, ms_va_list args);
+extern VOID LogHexdump_(const char *file, int line, const char *func,
+                        const void *data, size_t sz);
+extern VOID PrintErrors(VOID);
+extern VOID ClearErrors(VOID);
+
+#endif /* !ERRLOG_H_ */
+// vim:fenc=utf-8:tw=75:noet

--- a/include/errlog.h
+++ b/include/errlog.h
@@ -15,6 +15,8 @@ extern VOID LogHexdump_(const char *file, int line, const char *func,
                         const void *data, size_t sz);
 extern VOID PrintErrors(VOID);
 extern VOID ClearErrors(VOID);
+extern void save_logs(void);
+extern UINTN EFIAPI log_debug_print(const CHAR16 *fmt, ...);
 
 #endif /* !ERRLOG_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/load-options.c
+++ b/load-options.c
@@ -311,8 +311,13 @@ parse_load_options(EFI_LOADED_IMAGE *li)
 	UINT32 remaining_size;
 	CHAR16 *loader_str = NULL;
 
-	dprint(L"full load options:\n");
-	dhexdumpat(li->LoadOptions, li->LoadOptionsSize, 0);
+	if (!li->LoadOptions || !li->LoadOptionsSize) {
+		dprint(L"LoadOptions is empty\n");
+		return EFI_SUCCESS;
+	} else {
+		dprint(L"full LoadOptions:\n");
+		dhexdumpat(li->LoadOptions, li->LoadOptionsSize, 0);
+	}
 
 	/*
 	 * Sanity check since we make several assumptions about the length

--- a/shim.c
+++ b/shim.c
@@ -1182,6 +1182,8 @@ EFI_STATUS start_image(EFI_HANDLE image_handle, CHAR16 *ImagePath)
 		goto restore;
 	}
 
+	save_logs();
+
 	/*
 	 * The binary is trusted and relocated. Run it
 	 */

--- a/shim.h
+++ b/shim.h
@@ -166,6 +166,7 @@
 #include "include/crypt_blowfish.h"
 #include "include/dp.h"
 #include "include/efiauthenticated.h"
+#include "include/errlog.h"
 #include "include/errors.h"
 #include "include/execute.h"
 #include "include/guid.h"
@@ -240,14 +241,6 @@ typedef struct _SHIM_LOCK {
 
 extern EFI_STATUS shim_init(void);
 extern void shim_fini(void);
-extern EFI_STATUS EFIAPI LogError_(const char *file, int line, const char *func,
-                                   const CHAR16 *fmt, ...);
-extern EFI_STATUS EFIAPI VLogError(const char *file, int line, const char *func,
-                                   const CHAR16 *fmt, ms_va_list args);
-extern VOID LogHexdump_(const char *file, int line, const char *func,
-                        const void *data, size_t sz);
-extern VOID PrintErrors(VOID);
-extern VOID ClearErrors(VOID);
 extern VOID restore_loaded_image(VOID);
 extern EFI_STATUS start_image(EFI_HANDLE image_handle, CHAR16 *ImagePath);
 extern EFI_STATUS import_mok_state(EFI_HANDLE image_handle);


### PR DESCRIPTION
This changes our debug and error logging to save the entire logs into mok-variables as "shim-dbg.txt" and "shim-log.txt".