### PR TITLE
Disable log saving

### DIFF
--- a/globals.c
+++ b/globals.c
@@ -35,4 +35,7 @@ UINT8 mok_policy = 0;
 
 UINT32 verbose = 0;
 
+EFI_PHYSICAL_ADDRESS mok_config_table = 0;
+UINTN mok_config_table_pages = 0;
+
 // vim:fenc=utf-8:tw=75:noet

--- a/include/mok.h
+++ b/include/mok.h
@@ -127,6 +127,9 @@ struct mok_variable_config_entry {
 	UINT8 data[];
 };
 
+extern EFI_PHYSICAL_ADDRESS mok_config_table;
+extern UINTN mok_config_table_pages;
+
 /*
  * bit definitions for MokPolicy
  */

--- a/mok.c
+++ b/mok.c
@@ -1305,6 +1305,8 @@ EFI_STATUS import_mok_state(EFI_HANDLE image_handle)
 			config_table = NULL;
 		} else {
 			ZeroMem(config_table, npages << EFI_PAGE_SHIFT);
+			mok_config_table = (EFI_PHYSICAL_ADDRESS)(uintptr_t)config_table;
+			mok_config_table_pages = npages;
 		}
 	}
 

--- a/shim.c
+++ b/shim.c
@@ -1182,7 +1182,9 @@ EFI_STATUS start_image(EFI_HANDLE image_handle, CHAR16 *ImagePath)
 		goto restore;
 	}
 
+#if 0
 	save_logs();
+#endif
 
 	/*
 	 * The binary is trusted and relocated. Run it


### PR DESCRIPTION
It doesn't work reliably yet, and when it breaks it kills mok-variables along with it, so for now disable it.