### PR TITLE
Add MOK_POLICY variable to build options.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,11 @@ ifneq ($(origin FALLBACK_VERBOSE_WAIT), undefined)
 	CFLAGS += -DFALLBACK_VERBOSE_WAIT=$(FALLBACK_VERBOSE_WAIT)
 endif
 
+ifneq ($(origin MOK_POLICY), undefined)
+$(warning Setting default MOK policy to $(MOK_POLICY))
+	CFLAGS += -DMOK_POLICY_DEFAULT=$(MOK_POLICY)
+endif
+
 all: confcheck certcheck $(TARGETS)
 
 confcheck:

--- a/globals.c
+++ b/globals.c
@@ -31,7 +31,11 @@ UINT8 user_insecure_mode;
 UINTN hsi_status = 0;
 UINT8 ignore_db;
 UINT8 trust_mok_list;
+#ifdef MOK_POLICY_DEFAULT
+UINT8 mok_policy = MOK_POLICY_DEFAULT;
+#else
 UINT8 mok_policy = 0;
+#endif
 
 UINT32 verbose = 0;
 


### PR DESCRIPTION
This option allow to easily enforce mok policy flags at build time.