### PR TITLE
SBAT Level update for February 2025 GRUB CVEs

### DIFF
--- a/SbatLevel_Variable.txt
+++ b/SbatLevel_Variable.txt
@@ -118,12 +118,10 @@ grub,4
 grub.peimage,2
 
 
-Since http boot shim CVE is considerably more serious than then GRUB
-ntfs CVEs shim is delivering the shim revocation without the updated
-GRUB revocation as a latest payload.
+Revocations for:
+ - Februady 2025 GRUB CVEs
 
-To revoke both the impacted shim and impacted GRUB binaries:
-
-sbat,1,2024<date TBD>
+sbat,1,2025021800
 shim,4
-grub,4
+grub,5
+

--- a/generate_sbat_var_defs.c
+++ b/generate_sbat_var_defs.c
@@ -111,7 +111,7 @@ writefile()
 			       "#define GEN_SBAT_VAR_DEFS_H_\n"
 			       "#ifndef ENABLE_SHIM_DEVEL\n\n"
 			       "#ifndef SBAT_AUTOMATIC_DATE\n"
-			       "#define SBAT_AUTOMATIC_DATE 2023012900\n"
+			       "#define SBAT_AUTOMATIC_DATE 2024040900\n"
 			       "#endif /* SBAT_AUTOMATIC_DATE */\n"
 			       "#if SBAT_AUTOMATIC_DATE == %d\n"
 			       "#define SBAT_VAR_AUTOMATIC_REVOCATIONS\n",


### PR DESCRIPTION
Moves the minimum GRUB SBAT Level to 5 in order to require fixes for the following GRUB CVEs:

CVE-2024-45774
CVE-2024-45775
CVE-2024-45776
CVE-2024-45777
CVE-2024-45778
CVE-2024-45779
CVE-2024-45780
CVE-2024-45781
CVE-2024-45782
CVE-2024-45783
CVE-2025-0622
CVE-2025-0624
CVE-2025-0677
CVE-2025-0678
CVE-2025-0684
CVE-2025-0685
CVE-2025-0686
CVE-2025-0689
CVE-2025-0690
CVE-2025-1118
CVE-2025-1125