### PR TITLE
shim_start_image(): fix guid/handle pairing when uninstalling protocols

### DIFF
--- a/loader-proto.c
+++ b/loader-proto.c
@@ -311,8 +311,8 @@ shim_start_image(IN EFI_HANDLE ImageHandle, OUT UINTN *ExitDataSize,
 	// image unconditionally.
 	//
 	BS->UninstallMultipleProtocolInterfaces(ImageHandle,
-	                                &EFI_LOADED_IMAGE_GUID, image,
-	                                &SHIM_LOADED_IMAGE_GUID, &image->li,
+	                                &SHIM_LOADED_IMAGE_GUID, image,
+	                                &EFI_LOADED_IMAGE_GUID, &image->li,
 	                                &gEfiLoadedImageDevicePathProtocolGuid,
 					image->loaded_image_device_path,
 					NULL);


### PR DESCRIPTION
ardb noted in a comment on PR 656 that his code for shim_start_image() has the protocols and guids mismatched when we're uninstalling the protocol after the image has exited.

This fixes those to be paired correctly.