### PR TITLE
fix test segfaults caused by uninitialized memory

### DIFF
--- a/mock-variables.c
+++ b/mock-variables.c
@@ -1157,11 +1157,7 @@ mock_load_variables(const char *const dirname, const char *filters[],
 		printf("%s:%d:%s(): maybe adding entry \"%s\"\n", __FILE__, __LINE__, __func__, entry->d_name);
 #endif
 		if (filters && len > guidstr_size + 1) {
-			char spacebuf[len];
-
 			len -= guidstr_size;
-			SetMem(spacebuf, sizeof(spacebuf)-1, ' ');
-			spacebuf[len] = '\0';
 			for (size_t i = 0; filters[i]; i++) {
 				if (strlen(filters[i]) > len)
 					continue;

--- a/test-mock-variables.c
+++ b/test-mock-variables.c
@@ -212,8 +212,10 @@ test_gnvn_helper(char *testvars)
 		 * mok mirroring that aren't really from mok; right now
 		 * this is a reasonable heuristic for that.
 		 */
-		if (mok_state_variables[i].flags & MOK_VARIABLE_CONFIG_ONLY)
+		if (mok_state_variables[i].flags & MOK_VARIABLE_CONFIG_ONLY) {
+			mok_rt_vars[i] = "";
 			continue;
+		}
 		mok_rt_vars[i] = mok_state_variables[i].rtname8;
 	}
 
@@ -313,8 +315,10 @@ test_get_variable_0(void)
 		 * mok mirroring that aren't really from mok; right now
 		 * this is a reasonable heuristic for that.
 		 */
-		if (mok_state_variables[i].flags & MOK_VARIABLE_CONFIG_ONLY)
+		if (mok_state_variables[i].flags & MOK_VARIABLE_CONFIG_ONLY) {
+			mok_rt_vars[i] = "";
 			continue;
+		}
 		mok_rt_vars[i] = mok_state_variables[i].rtname8;
 	}
 


### PR DESCRIPTION
while preparing shim 16.0 for our Debian Bookworm based Debian derivative, I noticed the `test_get_variable_0` and `test_gnvn_0` tests failing (depending on SHIM_DEBUG value).

taking a closer look with gdb breaking at `test-mock-variables.c:310` for the `test_get_variable_0` case:

```
running test_install_config_table_0
test_install_config_table_0: passed
running test_get_variable_0

Breakpoint 1, test_get_variable_0 () at test-mock-variables.c:310
310             for (size_t i = 0; i < n_mok_state_variables; i++) {
(gdb) print mok_rt_vars
$1 = {0x7ffff7f6e9e0 <_IO_helper_jumps> "", 0x7ffff7f73760 <_IO_2_1_stdout_> "\207(\255", <incomplete sequence \373>, 0x0, 0x0, 0x0, 0x20676e696e6e7572 <error: Cannot access memory at address 0x20676e696e6e7572>,
  0x7465675f74736574 <error: Cannot access memory at address 0x7465675f74736574>, 0x6c6261697261765f <error: Cannot access memory at address 0x6c6261697261765f>, 0x736170200a305f65 <error: Cannot access memory at address 0x736170200a305f65>,
  0xa646573 <error: Cannot access memory at address 0xa646573>, 0x0 <repeats 20 times>}
(gdb) c
Continuing.

Program received signal SIGSEGV, Segmentation fault.
__strlen_evex () at ../sysdeps/x86_64/multiarch/strlen-evex.S:79
79      ../sysdeps/x86_64/multiarch/strlen-evex.S: No such file or directory.
(gdb) bt full
#0  __strlen_evex () at ../sysdeps/x86_64/multiarch/strlen-evex.S:79
No locals.
#1  0x000055555555d2e0 in mock_load_variables (dirname=dirname@entry=0x55555556ab30 "test-data/efivars-1", filters=0x7fffffffbb98, filter_out=filter_out@entry=true) at mock-variables.c:1166
        i = <optimized out>
        spacebuf = "         \000", ' ' <repeats 35 times>
        len = 9
        found = false
        dfd = 3
        d = 0x55555557d2a0
        entry = 0x55555557d300
#2  0x000055555555f4c3 in test_get_variable_0 () at test-mock-variables.c:321
        size = 0
        buf = '\000' <repeats 8191 times>
        status = <optimized out>
        empty_guid = <optimized out>
        attrs = 0
        ret = -1
        cmp = <optimized out>
        mok_rt_vars = {0x55555556a4b9 "MokListRT", 0x55555556a4cc "MokListXRT", 0x55555556a4e2 "MokSBStateRT", 0x55555556a4fa "MokIgnoreDB", 0x55555556a510 "SbatLevelRT", 0x55555556a52b "MokListTrustedRT", 0x55555556a546 "MokPolicyRT",
          0x6c6261697261765f <error: Cannot access memory at address 0x6c6261697261765f>, 0x736170200a305f65 <error: Cannot access memory at address 0x736170200a305f65>}
        __func__ = "test_get_variable_0"
        err = <optimized out>
#3  0x000055555555a717 in main () at test-mock-variables.c:868
        rc = <optimized out>
        status = 0
        policies = {0x55555556aded "MOCK_SORT_DESCENDING", 0x55555556ae02 "MOCK_SORT_PREPEND", 0x55555556ae14 "MOCK_SORT_APPEND", 0x55555556ae25 "MOCK_SORT_ASCENDING", 0x55555556ae39 "MOCK_SORT_MAX_SENTINEL"}
```

with Debian Trixie the test case passes, because there is no random memory contents at that location (slightly newer GCC 12, but might be some other cofounding factor affecting the memory layout or initialization):

```
test_gnvn_0: passed
running test_gnvn_1
test_gnvn_1: passed
running test_install_config_table_0
test_install_config_table_0: passed
running test_get_variable_0

Breakpoint 1, test_get_variable_0 () at test-mock-variables.c:310
310             for (size_t i = 0; i < n_mok_state_variables; i++) {
(gdb) print mok_rt_vars
$1 = {0x0 <repeats 30 times>}
```

in case there won't be any non-CONFIG_ONLY vars added later in the array, simple setting the first skipped entry to `NULL` and breaking the loop should also work.
