### PR TITLE
Fix uncompressed ipv6 netboot

### DIFF
--- a/netboot.c
+++ b/netboot.c
@@ -157,15 +157,20 @@ static CHAR8 *str2ip6(CHAR8 *str)
 		if (b[1] == ':' )
 			break;
 	}
-	a = b = (str + len);
-	for (j = len, p = 7; j > i; j--, a--) {
-		if (*a != ':')
-			continue;
-		t = *b;
-		*b = '\0';
-		ip[p--] = str2ns(a+1);
-		*b = t;
-		b = a;
+
+	if (i == len) {
+		ip[p++] = str2ns(a);
+	} else {
+		a = b = (str + len);
+		for (j = len, p = 7; j > i; j--, a--) {
+			if (*a != ':')
+				continue;
+			t = *b;
+			*b = '\0';
+			ip[p--] = str2ns(a+1);
+			*b = t;
+			b = a;
+		}
 	}
 	return (CHAR8 *)ip;
 }


### PR DESCRIPTION
In case the ipv6 is not in a compressed format, the last chunk gets set to 0 because the str2ns() never executes.

As an example, without this fix provided, str2ip6 works correctly on a compressed address like 

2400:dd00::1 -> 24 00 dd 00 00 00 00 00 00 00 00 00 00 00 00 01

but fails on

2400:dd00:1234:1234:1234:1234:1234:1234 -> 24 00 dd 00 12 34 12 34 12 34 12 34 12 34  00 00

The fixed routine returns 24 00 dd 00 12 34 12 34 12 34 12 34 12 34 12 34 as expected.