### PR TITLE
Realloc() needs to allocate one more byte for sprintf()

### DIFF
--- a/generate_sbat_var_defs.c
+++ b/generate_sbat_var_defs.c
@@ -57,7 +57,7 @@ readfile(char *SbatLevel_Variable)
 			       fgets(line, sizeof(line), varfilep) != NULL) {
 				char *new = NULL;
 				new = realloc(revlistentry->revocations,
-				              revocationsp + strlen(line) + 1);
+				              revocationsp + strlen(line) + 2);
 				if (new == NULL) {
 					ret = -1;
 					goto err;


### PR DESCRIPTION
In generate_sbat_var_defs.c, realloc() should allocate one more byte for the end of string '\0' when running sprintf() later. please also refer https://github.com/rhboot/shim/issues/744

Suppose we use fgets() to get line="abc\n", so strlen(line)=4 bytes. realloc(...,strlen(line),1) will allocate only 5 bytes which is not capable to save line(3 bytes),'\\' and 'n'(2 bytes) pluses extra '\0' byte totally 6 bytes when running sprintf(.....,"%s\\\n", line) later on. 
where '\n' of line has been removed in line[strlen(line) - 1] = 0;