### PR TITLE
Update CI to use ubuntu-24.04 instead of ubuntu-20.04

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   cross-build-pull-request:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: vathpela/efi-ci:${{ matrix.distro }}-x64
     name: ${{ matrix.distro }} ${{ matrix.efiarch }} cross-build
 
@@ -112,7 +112,7 @@ jobs:
           find /destdir -type f
 
   build-pull-request-intel:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: vathpela/efi-ci:${{ matrix.distro }}-x64
     name: ${{ matrix.distro }} ${{ matrix.efiarch }} build
 
@@ -184,7 +184,7 @@ jobs:
           find /destdir -type f
 
   build-pull-request-intel-compile-commands-json:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     container: vathpela/efi-ci:${{ matrix.distro }}-x64
     name: ${{ matrix.distro }} ${{ matrix.efiarch }} build compile_commands.json
 


### PR DESCRIPTION
Github deprecated ubuntu-20.04 earlier this month, and CI broke as a result.

This updates it to use ubuntu-24.04 (maybe it'll work?)