### PR TITLE
IPv6: Add more check to avoid multiple double colon and illegal char

### DIFF
--- a/netboot.c
+++ b/netboot.c
@@ -126,6 +126,7 @@ static CHAR16 str2ns(CHAR8 *str)
 
 static CHAR8 *str2ip6(CHAR8 *str)
 {
+	bool double_colon_found = false;
 	UINT8 i = 0, j = 0, p = 0;
 	size_t len = 0, dotcount = 0;
 	enum { MAX_IP6_DOTS = 7 };
@@ -147,6 +148,23 @@ static CHAR8 *str2ip6(CHAR8 *str)
 
 	len = strlen(str);
 	a = b = str;
+
+	for (i = 0; i < len; i++) {
+                if (str[i] == ':') {
+                        if (i+1 < (UINT8)len && str[i+1] == ':') {
+                                if (double_colon_found)
+                                        return (CHAR8 *)ip;
+                                double_colon_found = true;
+                        }
+                }
+                else {
+                        if (str[i] < '0' || (str[i] > '9' && str[i] < 'A') ||
+                           (str[i] > 'F' && str[i] < 'a') || str[i] > 'f')
+                                return (CHAR8 *)ip;
+                }
+        }
+
+
 	for (i = p = 0; i < len; i++, b++) {
 		if (*b != ':')
 			continue;


### PR DESCRIPTION
More than one double-colon in ipv6 address format is invalid. For example, the IPv6 address 2400::dd00::1 is invalid because it uses the :: (double colon) more than once, which is not allowed. This makes the address ambiguous: there's no way to know how many zero blocks each :: is supposed to compress. The IPv6 standard (RFC 4291) explicitly allows only one :: in an address.

Besides, the valid ipv6 characters only cover 0–9, a–f, and A–F