### PR TITLE
shim: change automatically enable MOK_POLICY_REQUIRE_NX

### DIFF
--- a/include/memattrs.h
+++ b/include/memattrs.h
@@ -13,6 +13,7 @@ extern EFI_STATUS update_mem_attrs(uintptr_t addr, uint64_t size,
 
 extern void get_hsi_mem_info(void);
 extern char *decode_hsi_bits(UINTN hsi);
+extern void set_shim_nx_policy(void);
 
 #endif /* !SHIM_MEMATTRS_H_ */
 // vim:fenc=utf-8:tw=75:noet

--- a/pe-relocate.c
+++ b/pe-relocate.c
@@ -661,5 +661,32 @@ get_shim_nx_capability(EFI_HANDLE image_handle)
 	}
 }
 
+static inline bool
+hsi_nx_is_enforced(void)
+{
+	return !((hsi_status & SHIM_HSI_STATUS_HEAPX) ||
+		 (hsi_status & SHIM_HSI_STATUS_STACKX) ||
+		 (hsi_status & SHIM_HSI_STATUS_ROW));
+}
+
+static inline bool
+hsi_api_is_present(void)
+{
+	return (hsi_status & SHIM_HSI_STATUS_HASMAP) ||
+		((hsi_status & SHIM_HSI_STATUS_HASDSTGMSD &&
+		  hsi_status & SHIM_HSI_STATUS_HASDSTSMSA));
+}
+
+void
+set_shim_nx_policy(void)
+{
+	if ((hsi_status & SHIM_HSI_STATUS_NX) &&
+	    hsi_nx_is_enforced() &&
+	    hsi_api_is_present())
+	{
+		mok_policy |= MOK_POLICY_REQUIRE_NX;
+		dprint("Enforcing NX policy for all images\n");
+	}
+}
 
 // vim:fenc=utf-8:tw=75:noet

--- a/shim.c
+++ b/shim.c
@@ -1238,6 +1238,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 
 	init_openssl();
 	get_hsi_mem_info();
+	set_shim_nx_policy();
 
 	efi_status = load_unbundled_trust(global_image_handle);
 	if (EFI_ERROR(efi_status)) {


### PR DESCRIPTION
Currently whether shim enforces NX on its downstream consumers is set at build time.  It would be better for this to be automatically detected and enforced.

This patch changes the policy to be dynamically detected.  In the case where shim has the NX bit set and the system has an appropriate protocol installed *and* appears to be enforcing NX, we enable the MOK policy bit to require NX.