### PR TITLE
add SbatLevel entry 2025051000 for PSA-2025-00012-1

### DIFF
--- a/SbatLevel_Variable.txt
+++ b/SbatLevel_Variable.txt
@@ -125,3 +125,10 @@ sbat,1,2025021800
 shim,4
 grub,5
 
+Revocations for
+- July 2025 Proxmox-specific Grub issue (PSA-2025-00012-1)
+
+sbat,1,2025051000
+shim,4
+grub,5
+grub.proxmox,2


### PR DESCRIPTION
From the advisory text:

> The NTFS fixes for the issues described in PSA-2025-00005-1 were reverted due
> to a regression. This was done under the assumption that the NTFS Grub module
> could not be loaded with Secure Boot enabled. However, this was not the case
> when the module was part of the monolithic GRUB EFI binary used in default
> setups that enable Secure Boot. To fix this, exclude the NTFS module from
> being part of the monolithic GRUB EFI binary.

This issue was specific to Proxmox variant of Grub 2.06 because:

- it contains a partial revert of the NTFS fixes from February 2025 that caused regressions
- it contains NTFS in the list of modules to be included in the signed Grub image
- it is still based on 2.06 with Debian's implementation of booting

This combination made the patch disallowing NTFS to be loaded while in lockdown mode ineffective, as the module was built into the (signed) monolithic EFI image used for booting.

We've released fixed Grub builds with our vendor specific SBAT level bumped to `proxmox.grub,2`, as in this commit.

See https://forum.proxmox.com/threads/149331/page-2#post-782751 and https://github.com/rhboot/shim-review/issues/467#issuecomment-3057526030 for details