### PR TITLE
pe: Fix PF in GRUB after memattrs call

### DIFF
--- a/loader-proto.c
+++ b/loader-proto.c
@@ -186,8 +186,6 @@ out:
 static void
 free_pages_alloc_image(SHIM_LOADED_IMAGE *image)
 {
-	char *buffer;
-
 	if (!image || !image->alloc_address || !image->alloc_pages)
 		return;
 
@@ -196,9 +194,8 @@ free_pages_alloc_image(SHIM_LOADED_IMAGE *image)
 	 * are set on a loaded image, this will cause a page fault when it
 	 * is freed. Ensure W+ X- are set instead before freeing. */
 
-	buffer = (void *)ALIGN_VALUE((unsigned long)image->alloc_address, image->alloc_alignment);
-	update_mem_attrs((uintptr_t)buffer, image->alloc_pages * PAGE_SIZE, MEM_ATTR_R|MEM_ATTR_W,
-			 MEM_ATTR_X);
+	update_mem_attrs((uintptr_t)image->alloc_address,
+			 image->alloc_pages * PAGE_SIZE, MEM_ATTR_R|MEM_ATTR_W, MEM_ATTR_X);
 
 	BS->FreePages(image->alloc_address, image->alloc_pages);
 	image->alloc_address = 0;

--- a/pe.c
+++ b/pe.c
@@ -717,7 +717,7 @@ handle_image (void *data, unsigned int datasize,
 	dprint(L"Loading 0x%llx bytes at 0x%llx\n",
 	       (unsigned long long)context.ImageSize,
 	       (unsigned long long)(uintptr_t)buffer);
-	update_mem_attrs((uintptr_t)buffer, alloc_size, MEM_ATTR_R|MEM_ATTR_W,
+	update_mem_attrs((uintptr_t)buffer, context.ImageSize, MEM_ATTR_R|MEM_ATTR_W,
 			 MEM_ATTR_X);
 
 	CopyMem(buffer, data, context.SizeOfHeaders);


### PR DESCRIPTION
The call to update_mem_attrs() takes an aligned pointer within an allocated region but passes the entire size of the allocated region. The result is that Shim may remove execute permission from some pages belonging to GRUB causing a page fault upon returning from the LoadImage call.