### PR TITLE
tests: fix build on musl-based systems

### DIFF
--- a/include/test.mk
+++ b/include/test.mk
@@ -13,6 +13,8 @@ DEBUG_PRINTS ?= 0
 OPTIMIZATIONS=-O2 -ggdb
 CFLAGS_LTO =
 CFLAGS_GCOV =
+LIBS = -lefivar
+
 CFLAGS = $(OPTIMIZATIONS) -std=gnu11 \
 	 -isystem $(TOPDIR)/include/system \
 	 $(EFI_INCLUDES) \
@@ -45,6 +47,11 @@ CFLAGS = $(OPTIMIZATIONS) -std=gnu11 \
 	 -DGNU_EFI_USE_MS_ABI -DPAGE_SIZE=4096 \
 	 -DSHIM_UNIT_TEST \
 	 "-DDEFAULT_DEBUG_PRINT_STATE=$(DEBUG_PRINTS)"
+
+ifneq ($(origin ENABLE_LIBUNWIND), undefined)
+CFLAGS += -DENABLE_LIBUNWIND
+LIBS += -lunwind
+endif
 
 # On some systems (e.g. Arch Linux), limits.h is in the "include-fixed" instead
 # of the "include" directory
@@ -109,7 +116,7 @@ tests := $(patsubst %.c,%,$(wildcard test-*.c))
 $(tests) :: test-% : | libefi-test.a
 
 $(tests) :: test-% : test.c test-%.c $(test-%_FILES)
-	$(CC) $(CFLAGS) -o $@ $(sort $^ $(wildcard $*.c) $(test-$*_FILES)) libefi-test.a -lefivar
+	$(CC) $(CFLAGS) -o $@ $(sort $^ $(wildcard $*.c) $(test-$*_FILES)) libefi-test.a $(LIBS)
 	$(VALGRIND) ./$@
 
 test : $(tests)

--- a/test-load-options.c
+++ b/test-load-options.c
@@ -14,7 +14,6 @@
 
 #include "shim.h"
 
-#include <execinfo.h>
 #include <stdio.h>
 #include <efivar/efivar.h>
 

--- a/test-str.c
+++ b/test-str.c
@@ -931,7 +931,7 @@ test_strncpy(void)
 
 	memset(s0, 0, sizeof(s0));
 	memcpy(s0, s, sizeof(s));
-#if __GNUC_PREREQ(8, 1)
+#if GNUC_PREREQ(8, 1)
 # pragma GCC diagnostic push
 # pragma GCC diagnostic ignored "-Wstringop-truncation"
 #endif
@@ -1033,7 +1033,7 @@ test_strncpy(void)
 	assert_equal_return(s1[16], '\000', -1, "got %#02hhx expected %02hhx\n");
 	assert_equal_return(s1[17], '0', -1, "got %#02hhx expected %02hhx\n");
 	assert_equal_return(s1[18], '1', -1, "got %#02hhx expected %02hhx\n");
-#if __GNUC_PREREQ(8, 1)
+#if GNUC_PREREQ(8, 1)
 # pragma GCC diagnostic pop
 #endif
 	return 0;


### PR DESCRIPTION
This PR addresses two issues related to glibc-specific usage in the tests to ensure they can be built with musl libc too:

* the use of `__GNUC_PREREQ` macro from `features.h` - replaced with GNUC_PREREQ that is provided by `shim.h` and implements the same functionality.
* and the use of `execinfo.h` (backtrace functions) - musl libc does not provide the backtrace functions in its implementation. These functions are typically provided by glibc's `execinfo.h`. As a fallback for musl-based systems, support linking against the external libunwind library and using dladdr() to obtain similar stack trace info. Note that the usage of dladdr() is similar to that of backtrace_symbols in glibc, and it can be used with glibc as well.
