### PR TITLE
mok: Add a building option to avoid the vendor_dbx being appended to …

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -75,6 +75,17 @@ Variables you could set to customize the build:
 - ENABLE_CODESIGN_EKU
   This changes the certificate validation logic to require Extended Key
   Usage 1.3.6.1.5.5.7.3.3 ("Code Signing").
+- DISABLE_APPEND_V_DBX_TO_MOKX
+  This building option avoids the vendor_dbx being appended to MokListRT.
+  Instead, the vendor_dbx will be exposed through the mok config table space.
+  As the vendor-dbx grows, it caused some problems when writing such
+  a large variable. Some firmwares lie the avaiable space(*1), and some
+  even crash(*2) for no good reason after the writing of MokListXRT. If
+  your shim and kernel don't rely on MokListXRT to block anything, you can
+  use this building option to expose vendor_dbx through the mok config table
+  instead of appending it to MokListRT.
+  (*1) https://bugzilla.suse.com/show_bug.cgi?id=1185261
+  (*2) https://github.com/rhboot/shim/pull/369#issuecomment-855275115
 
 Vendor SBAT data:
 It will sometimes be requested by reviewers that a build includes extra

--- a/Make.defaults
+++ b/Make.defaults
@@ -164,6 +164,10 @@ ifneq ($(origin DISABLE_REMOVABLE_LOAD_OPTIONS), undefined)
 	DEFINES  += -DDISABLE_REMOVABLE_LOAD_OPTIONS
 endif
 
+ifneq ($(origin DISABLE_APPEND_V_DBX_TO_MOKX), undefined)
+	DEFINES  += -DDISABLE_APPEND_V_DBX_TO_MOKX
+endif
+
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --output-target efi-app-$(ARCH)

--- a/mok.c
+++ b/mok.c
@@ -333,8 +333,10 @@ struct mok_state_variable mok_state_variable_data[] = {
 		     EFI_VARIABLE_NON_VOLATILE,
 	 .no_attr = EFI_VARIABLE_RUNTIME_ACCESS,
 	 .categorize_addend = categorize_deauthorized,
+#if !defined(DISABLE_APPEND_V_DBX_TO_MOKX)
 	 .addend = &vendor_deauthorized,
 	 .addend_size = &vendor_deauthorized_size,
+#endif	/* !defined(DISABLE_APPEND_V_DBX_TO_MOKX) */
 	 .flags = MOK_MIRROR_KEYDB |
 		  MOK_MIRROR_DELETE_FIRST |
 		  MOK_VARIABLE_LOG,
@@ -566,6 +568,19 @@ struct mok_state_variable mok_state_variable_data[] = {
 	 .guid = &SECUREBOOT_EFI_NAMESPACE_GUID,
 	 .flags = MOK_VARIABLE_CONFIG_ONLY,
 	},
+#if defined(DISABLE_APPEND_V_DBX_TO_MOKX)
+	{.name = L"VendorDBX",
+	 .name8 = "VendorDBX",
+	 .rtname = L"VendorDBX",
+	 .rtname8 = "VendorDBX",
+	 .guid = &SHIM_LOCK_GUID,
+	 .categorize_addend = categorize_deauthorized,
+	 .addend = &vendor_deauthorized,
+	 .addend_size = &vendor_deauthorized_size,
+	 .flags = MOK_MIRROR_KEYDB |
+		  MOK_VARIABLE_CONFIG_ONLY,
+	},
+#endif	/* defined(DISABLE_APPEND_V_DBX_TO_MOKX) */
 	/*
 	 * Keep this entry last, or it'll be wrong.
 	 */


### PR DESCRIPTION
…MokListRT

The new building option DISABLE_APPEND_V_DBX_TO_MOKX avoids appending the vendor_dbx to MokListRT. Instead, the vendor_dbx will be exposed through the mok config table space.

As the vendor-dbx grows, it caused some problems when writing such a large variable. Some firmwares lie the avaiable space [1], and some even crash [2] for no good reason after the writing of MokListXRT. If your shim and kernel don't rely on MokListXRT to block anything, you can use this building option to expose vendor_dbx through the mok config table instead of appending it to MokListRT.

Link: https://bugzilla.suse.com/show_bug.cgi?id=1185261 [1]
Link: https://github.com/rhboot/shim/pull/369#issuecomment-855275115 [2]