### PR TITLE
Fix -Wstrict-prototypes warnings

### DIFF
--- a/MokManager.c
+++ b/MokManager.c
@@ -737,7 +737,7 @@ done:
 	return efi_status;
 }
 
-static INTN reset_system()
+static INTN reset_system(void)
 {
 	RT->ResetSystem(EfiResetWarm, EFI_SUCCESS, 0, NULL);
 	console_notify(L"Failed to reboot\n");
@@ -2152,7 +2152,7 @@ static BOOLEAN verify_pw(BOOLEAN * protected)
 	return TRUE;
 }
 
-static int draw_countdown()
+static int draw_countdown(void)
 {
 	CHAR16 *message = L"Press any key to perform MOK management";
 	CHAR16 *title;

--- a/sbat.c
+++ b/sbat.c
@@ -456,7 +456,7 @@ preserve_ssp_uefi_variable(UINT8 *ssp_applied, UINTN sspversize, UINT32 attribut
 }
 
 static void
-clear_sbat_policy()
+clear_sbat_policy(void)
 {
 	EFI_STATUS efi_status = EFI_SUCCESS;
 


### PR DESCRIPTION
Use void instead of empty parentheses.

sbat.c:459:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  459 | clear_sbat_policy()
      | ^~~~~~~~~~~~~~~~~
MokManager.c:740:13: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  740 | static INTN reset_system()
      |             ^~~~~~~~~~~~
MokManager.c:2155:12: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 2155 | static int draw_countdown()
      |            ^~~~~~~~~~~~~~