### PR TITLE
Fix some Infer Dead Store warnings

### DIFF
--- a/csv.c
+++ b/csv.c
@@ -50,7 +50,7 @@ free_csv_list(list_t *list)
 EFI_STATUS
 parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
 {
-	EFI_STATUS efi_status = EFI_OUT_OF_RESOURCES;
+	EFI_STATUS efi_status;
 	char delims[] = "\r\n";
 	char *line = data;
 	size_t max = 0;

--- a/fallback.c
+++ b/fallback.c
@@ -68,7 +68,7 @@ static EFI_STATUS
 FindSubDevicePath(EFI_DEVICE_PATH *In, UINT8 Type, UINT8 SubType,
 		  EFI_DEVICE_PATH **Out)
 {
-	EFI_DEVICE_PATH *dp = In;
+	EFI_DEVICE_PATH *dp;
 	if (!In || !Out)
 		return EFI_INVALID_PARAMETER;
 

--- a/post-process-pe.c
+++ b/post-process-pe.c
@@ -122,7 +122,7 @@ load_pe(const char *const file, void *const data, const size_t datasize,
         PE_COFF_LOADER_IMAGE_CONTEXT *ctx)
 {
 	EFI_IMAGE_DOS_HEADER *DOSHdr = data;
-	EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr = data;
+	EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr;
 	size_t HeaderWithoutDataDir, SectionHeaderOffset, OptHeaderSize;
 	size_t FileAlignment = 0;
 	size_t sz0 = 0, sz1 = 0;
@@ -390,7 +390,6 @@ validate_nx_compat(PE_COFF_LOADER_IMAGE_CONTEXT *ctx)
 			ret = -1;
 	}
 
-	Section = ctx->FirstSection;
 	for (i=0, Section = ctx->FirstSection; i < ctx->NumberOfSections; i++, Section++) {
 		debug(NOISE, "Section %d has WRITE=%d and EXECUTE=%d\n", i,
 		      (Section->Characteristics & EFI_IMAGE_SCN_MEM_WRITE) ? 1 : 0,


### PR DESCRIPTION
Fix some Dead Store warnings found by the Infer static analysis tool:

csv.c:53: error: Dead Store
  The value written to `&efi_status` is never used.
  51. parse_csv_data(char *data, char *data_end, size_t n_columns, list_t *list)
  52. {
  53. 	EFI_STATUS efi_status = EFI_OUT_OF_RESOURCES; ^
  54. 	char delims[] = "\r\n";
  55. 	char *line = data;

fallback.c:71: error: Dead Store
  The value written to `&dp` is never used.
  69. 		  EFI_DEVICE_PATH **Out)
  70. {
  71. 	EFI_DEVICE_PATH *dp = In; ^
  72. 	if (!In || !Out)
  73. 		return EFI_INVALID_PARAMETER;

post-process-pe.c:125: error: Dead Store
  The value written to `&PEHdr` is never used.
  123. {
  124. 	EFI_IMAGE_DOS_HEADER *DOSHdr = data;
  125. 	EFI_IMAGE_OPTIONAL_HEADER_UNION *PEHdr = data; ^
  126. 	size_t HeaderWithoutDataDir, SectionHeaderOffset, OptHeaderSize;
  127. 	size_t FileAlignment = 0;

post-process-pe.c:393: error: Dead Store
  The value written to `&Section` is never used.
  391. 	} 392.
  393. 	Section = ctx->FirstSection; ^
  394. 	for (i=0, Section = ctx->FirstSection; i < ctx->NumberOfSections; i++, Section++) {
  395. 		debug(NOISE, "Section %d has WRITE=%d and EXECUTE=%d\n", i,