### PR TITLE
Fix build with binutils 2.46

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -155,7 +155,7 @@ endif
 
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
-FORMAT		?= --target efi-app-$(ARCH)
+FORMAT		?= --output-target efi-app-$(ARCH)
 LOCAL_EFI_PATH	= gnu-efi/$(ARCH_GNUEFI)/gnuefi
 LIBDIR		= gnu-efi/$(ARCH_GNUEFI)/lib
 


### PR DESCRIPTION
With the new binutils which is in development and in Fedora Rawhide:

```
objcopy -D -j .text -j .sdata -j .data -j .data.ident \
        -j .dynamic -j .rodata -j .rel* \
        -j .rela* -j .dyn -j .reloc -j .eh_frame \
        -j .vendor_cert -j .sbat -j .sbatlevel \
        --file-alignment 0x1000 \
        --target efi-app-x86_64 fbx64.so fbx64.efi
objcopy: fbx64.so: file format not recognized
```

It seems it was an intentional compat break, according to the upstream commit:

https://sourceware.org/git/gitweb.cgi?p=binutils-gdb.git;a=commit;h=5e83077d552ed6f81dbc092eb3ccf827a43de42c

> Internal changes to plugin support, and stricter target checking may result in some errors being exposed in user options passed to the various binutils. For example objcopy --target=TARGET now will only work if the input file is for TARGET whereas prior versions of objcopy accepted other target input files and produced a TARGET output.  If you do in fact want the old behaviour the correct usage is objcopy --output-target=TARGET.

Switch from --taget to --output-target as suggested.