### PR TITLE
shim: Fix memory leak in HTTP boot path

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -338,6 +338,7 @@ EFI_STATUS read_image(EFI_HANDLE image_handle, CHAR16 *ImagePath,
 				       netbootname, efi_status);
 			return efi_status;
 		}
+		FreePool(netbootname);
 		*data = sourcebuffer;
 		*datasize = sourcesize;
 	} else {


### PR DESCRIPTION
In the HTTP boot path of read_image(), netbootname is allocated by str16_to_str8() but was not being freed after httpboot_fetch_buffer() returns, causing a memory leak.