### PR TITLE
fallback: fix memory leak in find_boot_csv()

### DIFF
--- a/fallback.c
+++ b/fallback.c
@@ -825,6 +825,12 @@ find_boot_csv(EFI_FILE_HANDLE fh, CHAR16 *dirname,
 					      dirname, bootarchcsv, efi_status);
 		}
 	}
+
+	if (bootcsv)
+		FreePool(bootcsv);
+	if (bootarchcsv)
+		FreePool(bootarchcsv);
+
 	return EFI_SUCCESS;
 }
 


### PR DESCRIPTION
In find_boot_csv(), bootcsv and bootarchcsv are allocated by StrDuplicate() but were not being freed before the function returns, causing a memory leak.