### PR TITLE
CI: Update from f39/f40/f41 to f42/f43/f44

### DIFF
--- a/.github/workflows/mkosi.yml
+++ b/.github/workflows/mkosi.yml
@@ -67,7 +67,7 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: systemd/mkosi@main

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -81,7 +81,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
@@ -168,7 +168,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}
@@ -225,7 +225,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # otherwise we are testing target branch instead of the PR branch (see pull_request_target trigger)
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -22,57 +22,62 @@ jobs:
             efiarch: aa64
             gccarch: aarch64
             makearch: aarch64
-            distro: f41
+            distro: f45
           - arch: amd64
             efiarch: aa64
             gccarch: aarch64
             makearch: aarch64
-            distro: f40
+            distro: f44
+          - arch: amd64
+            efiarch: aa64
+            gccarch: aarch64
+            makearch: aarch64
+            distro: f43
           - arch: amd64
             efiarch: arm
             gccarch: arm
             makearch: arm
-            distro: f41
+            distro: f45
           - arch: amd64
             efiarch: arm
             gccarch: arm
             makearch: arm
-            distro: f40
+            distro: f44
           - arch: amd64
             efiarch: arm
             gccarch: arm
             makearch: arm
-            distro: f39
+            distro: f43
           - arch: amd64
             efiarch: x64
             gccarch: x86_64
             makearch: x86_64
-            distro: f41
+            distro: f45
           - arch: amd64
             efiarch: x64
             gccarch: x86_64
             makearch: x86_64
-            distro: f40
+            distro: f44
           - arch: amd64
             efiarch: x64
             gccarch: x86_64
             makearch: x86_64
-            distro: f39
+            distro: f43
           - arch: amd64
             efiarch: ia32
             gccarch: x86_64
             makearch: ia32
-            distro: f41
+            distro: f45
           - arch: amd64
             efiarch: ia32
             gccarch: x86_64
             makearch: ia32
-            distro: f40
+            distro: f44
           - arch: amd64
             efiarch: ia32
             gccarch: x86_64
             makearch: ia32
-            distro: f39
+            distro: f43
 
     steps:
       - name: Checkout
@@ -122,15 +127,15 @@ jobs:
           - arch: amd64
             efiarch: x64
             makearch: x86_64
-            distro: f41
+            distro: f45
           - arch: amd64
             efiarch: x64
             makearch: x86_64
-            distro: f40
+            distro: f44
           - arch: amd64
             efiarch: x64
             makearch: x86_64
-            distro: f39
+            distro: f43
           - arch: amd64
             efiarch: x64
             makearch: x86_64
@@ -142,7 +147,15 @@ jobs:
           - arch: amd64
             efiarch: ia32
             makearch: ia32
-            distro: f39
+            distro: f45
+          - arch: amd64
+            efiarch: ia32
+            makearch: ia32
+            distro: f44
+          - arch: amd64
+            efiarch: ia32
+            makearch: ia32
+            distro: f43
           - arch: amd64
             efiarch: ia32
             makearch: ia32
@@ -194,7 +207,15 @@ jobs:
           - arch: amd64
             efiarch: x64
             makearch: x86_64
-            distro: f41
+            distro: f45
+          - arch: amd64
+            efiarch: x64
+            makearch: x86_64
+            distro: f44
+          - arch: amd64
+            efiarch: x64
+            makearch: x86_64
+            distro: f43
 
     steps:
       - name: Checkout

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -122,6 +122,7 @@ jobs:
     name: ${{ matrix.distro }} ${{ matrix.efiarch }} build
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64
@@ -206,6 +207,7 @@ jobs:
     name: ${{ matrix.distro }} ${{ matrix.efiarch }} build compile_commands.json
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - arch: amd64

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -139,6 +139,10 @@ jobs:
           - arch: amd64
             efiarch: x64
             makearch: x86_64
+            distro: centos10
+          - arch: amd64
+            efiarch: x64
+            makearch: x86_64
             distro: centos9
           - arch: amd64
             efiarch: x64

--- a/lib/string.c
+++ b/lib/string.c
@@ -17,6 +17,9 @@
 #define strncmp shim_strncmp
 #define strncasecmp shim_strncasecmp
 #define strcasecmp shim_strcasecmp
+#ifdef strrchr
+#undef strrchr
+#endif
 #define strrchr shim_strrchr
 #define strlen shim_strlen
 #define strnlen shim_strnlen


### PR DESCRIPTION
Fedora 41 is pretty old, so update to some supported (or nearly supported) OSes.