### PR TITLE
Fix formatting issue in init_grub

### DIFF
--- a/shim.c
+++ b/shim.c
@@ -438,7 +438,7 @@ EFI_STATUS init_grub(EFI_HANDLE image_handle)
 	EFI_STATUS efi_status;
 	int use_fb = should_use_fallback(image_handle);
 
-	efi_status = start_image(image_handle, use_fb ? FALLBACK :second_stage);
+	efi_status = start_image(image_handle, use_fb ? FALLBACK : second_stage);
 	if (efi_status == EFI_SECURITY_VIOLATION ||
 	    efi_status == EFI_ACCESS_DENIED) {
 		efi_status = start_image(image_handle, MOK_MANAGER);


### PR DESCRIPTION
space after double colon in ternary operator