### PR TITLE
mkosi: Use Debian stable

### DIFF
--- a/mkosi/mkosi.conf
+++ b/mkosi/mkosi.conf
@@ -8,6 +8,8 @@ OutputDirectory=mkosi.output
 [Build]
 History=yes
 ToolsTree=default
+ToolsTreeDistribution=debian
+ToolsTreeRelease=stable
 BuildDirectory=mkosi.builddir
 CacheDirectory=mkosi.cache
 Incremental=yes

--- a/mkosi/mkosi.conf.d/debian/mkosi.conf
+++ b/mkosi/mkosi.conf.d/debian/mkosi.conf
@@ -1,0 +1,5 @@
+[Match]
+Distribution=|debian
+
+[Distribution]
+Release=stable


### PR DESCRIPTION
This restores CI functionality for the most part, modulo a couple CentOS failures that we were already [aware of](https://github.com/rhboot/shim/pull/777#issuecomment-4790364304) and for which a fix is being prepared on the CentOS side.

I will file an issue against mkosi to try and figure out how to get the Debian testing jobs working again, but in the meantime this allows us to validate incoming changes.