### PR TITLE
Periodically update the UEFI watchdog timer when we're printing to the console...

### DIFF
--- a/Cryptlib/Include/CrtLibSupport.h
+++ b/Cryptlib/Include/CrtLibSupport.h
@@ -115,7 +115,6 @@ SPDX-License-Identifier: BSD-2-Clause-Patent
 // Basic types mapping
 //
 typedef UINTN   off_t;
-typedef INT64   time_t;
 typedef UINT8   sa_family_t;
 typedef UINT32  uid_t;
 typedef UINT32  gid_t;
@@ -126,28 +125,11 @@ typedef UINT32  gid_t;
 //
 typedef VOID *FILE;
 
+#include "CrtLibTime.h"
+
 //
 // Structures Definitions
 //
-struct tm {
-  int     tm_sec;    /* seconds after the minute [0-60] */
-  int     tm_min;    /* minutes after the hour [0-59] */
-  int     tm_hour;   /* hours since midnight [0-23] */
-  int     tm_mday;   /* day of the month [1-31] */
-  int     tm_mon;    /* months since January [0-11] */
-  int     tm_year;   /* years since 1900 */
-  int     tm_wday;   /* days since Sunday [0-6] */
-  int     tm_yday;   /* days since January 1 [0-365] */
-  int     tm_isdst;  /* Daylight Savings Time flag */
-  long    tm_gmtoff; /* offset from CUT in seconds */
-  char    *tm_zone;  /* timezone abbreviation */
-};
-
-struct timeval {
-  long    tv_sec;   /* time value, in seconds */
-  long    tv_usec;  /* time value, in microseconds */
-};
-
 struct dirent {
   UINT32  d_fileno;         /* file number of entry */
   UINT16  d_reclen;         /* length of this record */

--- a/Cryptlib/Include/CrtLibSupport.h
+++ b/Cryptlib/Include/CrtLibSupport.h
@@ -254,6 +254,5 @@ void setbuf(FILE *, char *buffer);
 #define assert(expression)
 #define atoi(nptr)                        AsciiStrDecimalToUintn((const CHAR8 *)nptr)
 #define gettimeofday(tvp,tz)              ({ (tvp)->tv_sec = time(NULL); (tvp)->tv_usec = 0; 0;})
-#define gmtime_r(timer,result)            (result = NULL)
 
 #endif

--- a/Cryptlib/Include/CrtLibTime.h
+++ b/Cryptlib/Include/CrtLibTime.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/*
+ * CrtLibTime.h - stdlib time structure and type definitions.
+ *
+ * Copyright (c) 2010 - 2022, Intel Corporation. All rights reserved.
+ * Copyright (c) 2020, Hewlett Packard Enterprise Development LP. All rights reserved.
+ * Copyright (c) 2022, Loongson Technology Corporation Limited. All rights reserved.
+ */
+
+#pragma once
+
+//
+// Basic types mapping
+//
+typedef INT64   time_t;
+
+//
+// Structures Definitions
+//
+struct tm {
+  int     tm_sec;    /* seconds after the minute [0-60] */
+  int     tm_min;    /* minutes after the hour [0-59] */
+  int     tm_hour;   /* hours since midnight [0-23] */
+  int     tm_mday;   /* day of the month [1-31] */
+  int     tm_mon;    /* months since January [0-11] */
+  int     tm_year;   /* years since 1900 */
+  int     tm_wday;   /* days since Sunday [0-6] */
+  int     tm_yday;   /* days since January 1 [0-365] */
+  int     tm_isdst;  /* Daylight Savings Time flag */
+  long    tm_gmtoff; /* offset from CUT in seconds */
+  char    *tm_zone;  /* timezone abbreviation */
+};
+
+struct timeval {
+  long    tv_sec;   /* time value, in seconds */
+  long    tv_usec;  /* time value, in microseconds */
+};

--- a/Cryptlib/SysCall/TimerWrapper.c
+++ b/Cryptlib/SysCall/TimerWrapper.c
@@ -85,15 +85,22 @@ CalculateTimeT (
   EFI_TIME  *Time
   )
 {
-  time_t  CalTime;
+  time_t  CalTime = 0;
   UINTN   Year;
 
   //
   // Years Handling
   // UTime should now be set to 00:00:00 on Jan 1 of the current year.
   //
-  for (Year = 1970, CalTime = 0; Year != Time->Year; Year++) {
-    CalTime = CalTime + (time_t)(CumulativeDays[IsLeap (Year)][13] * SECSPERDAY);
+  if (Time->Year < 1970) {
+    for (Year = 1970; Year > Time->Year; Year--) {
+      CalTime -= (time_t)(CumulativeDays[IsLeap (Year)][13] * SECSPERDAY);
+    }
+    CalTime -= 86400;
+  } else {
+    for (Year = 1970; Year < Time->Year; Year++) {
+      CalTime += (time_t)(CumulativeDays[IsLeap (Year)][13] * SECSPERDAY);
+    }
   }
 
   //

--- a/Cryptlib/SysCall/TimerWrapper.c
+++ b/Cryptlib/SysCall/TimerWrapper.c
@@ -162,8 +162,9 @@ mktime (
 // Convert a time value from type time_t to struct tm.
 //
 struct tm *
-gmtime (
-  const time_t  *timer
+gmtime_r (
+  const time_t * restrict timer,
+  struct tm * restrict result
   )
 {
   struct tm  *GmTime;
@@ -175,14 +176,11 @@ gmtime (
   UINT32     MonthNo;
   INT64      Remainder;
 
-  if (timer == NULL) {
+  if (timer == NULL || result == NULL) {
     return NULL;
   }
 
-  GmTime = malloc (sizeof (struct tm));
-  if (GmTime == NULL) {
-    return NULL;
-  }
+  GmTime = result;
 
   ZeroMem ((VOID *)GmTime, (UINTN)sizeof (struct tm));
 
@@ -223,6 +221,28 @@ gmtime (
   GmTime->tm_isdst  = 0;
   GmTime->tm_gmtoff = 0;
   GmTime->tm_zone   = NULL;
+
+  return GmTime;
+}
+
+struct tm *
+gmtime (
+  const time_t  *timer
+  )
+{
+  struct tm * GmTime;
+
+  if (!timer) {
+    errno = EINVAL;
+    return NULL;
+  }
+
+  GmTime = malloc (sizeof (struct tm));
+  if (GmTime == NULL) {
+    return NULL;
+  }
+
+  gmtime_r(timer, GmTime);
 
   return GmTime;
 }

--- a/Makefile
+++ b/Makefile
@@ -38,13 +38,86 @@ CFLAGS += -DENABLE_SHIM_CERT
 else
 TARGETS += $(MMNAME) $(FBNAME)
 endif
-OBJS	= shim.o globals.o memattrs.o mok.o netboot.o cert.o dp.o loader-proto.o tpm.o version.o errlog.o sbat.o sbat_data.o sbat_var.o pe.o pe-relocate.o httpboot.o csv.o load-options.o utils.o verify.o
-KEYS	= shim_cert.h ocsp.* ca.* shim.crt shim.csr shim.p12 shim.pem shim.key shim.cer
-ORIG_SOURCES	= shim.c globals.c memattrs.c mok.c netboot.c dp.c loader-proto.c tpm.c errlog.c sbat.c pe.c pe-relocate.c httpboot.c verify.c shim.h version.h $(wildcard include/*.h) cert.S sbat_var.S
-MOK_OBJS = MokManager.o PasswordCrypt.o crypt_blowfish.o errlog.o sbat_data.o globals.o dp.o utils.o
-ORIG_MOK_SOURCES = MokManager.c PasswordCrypt.c crypt_blowfish.c shim.h $(wildcard include/*.h)
-FALLBACK_OBJS = fallback.o tpm.o errlog.o sbat_data.o globals.o utils.o
+
+OBJS	= shim.o \
+	  cert.o \
+	  csv.o \
+	  dp.o \
+	  errlog.o \
+	  httpboot.o \
+	  globals.o \
+	  load-options.o \
+	  loader-proto.o \
+	  memattrs.o \
+	  mok.o \
+	  netboot.o \
+	  pe.o \
+	  pe-relocate.o \
+	  sbat.o \
+	  sbat_data.o \
+	  sbat_var.o \
+	  tpm.o \
+	  utils.o \
+	  verify.o \
+	  version.o \
+
+KEYS	= shim_cert.h \
+	  ocsp.* \
+	  ca.* \
+	  shim.crt \
+	  shim.csr \
+	  shim.p12 \
+	  shim.pem \
+	  shim.key \
+	  shim.cer \
+
+ORIG_SOURCES	= shim.c \
+		  cert.S \
+		  csv.c \
+		  dp.c \
+		  errlog.c \
+		  httpboot.c \
+		  globals.c \
+		  load-options.c \
+		  loader-proto.c \
+		  memattrs.c \
+		  mok.c \
+		  netboot.c \
+		  pe.c \
+		  pe-relocate.c \
+		  sbat.c \
+		  sbat_var.S \
+		  shim.h \
+		  tpm.c \
+		  utils.c \
+		  verify.c \
+		  version.h \
+		  $(wildcard include/*.h) \
+
+MOK_OBJS = MokManager.o \
+	   crypt_blowfish.o \
+	   dp.o \
+	   errlog.o \
+	   globals.o \
+	   PasswordCrypt.o \
+	   sbat_data.o \
+	   utils.o \
+
+ORIG_MOK_SOURCES = MokManager.c \
+		   crypt_blowfish.c \
+		   PasswordCrypt.c \
+		   shim.h \
+		   $(wildcard include/*.h) \
+
+FALLBACK_OBJS = fallback.o \
+		errlog.o \
+		globals.o \
+		sbat_data.o \
+		tpm.o \
+		utils.o
+
 ORIG_FALLBACK_SRCS = fallback.c
+
 SBATPATH = $(TOPDIR)/data/sbat.csv
 
 ifeq ($(SOURCE_DATE_EPOCH),)

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ OBJS	= shim.o \
 	  sbat.o \
 	  sbat_data.o \
 	  sbat_var.o \
+	  time.o \
 	  tpm.o \
 	  utils.o \
 	  verify.o \
@@ -90,6 +91,7 @@ ORIG_SOURCES	= shim.c \
 		  sbat.c \
 		  sbat_var.S \
 		  shim.h \
+		  time.c \
 		  tpm.c \
 		  utils.c \
 		  verify.c \
@@ -104,6 +106,7 @@ MOK_OBJS = MokManager.o \
 	   hexdump.o \
 	   PasswordCrypt.o \
 	   sbat_data.o \
+	   time.o \
 	   utils.o \
 
 ORIG_MOK_SOURCES = MokManager.c \
@@ -117,6 +120,7 @@ FALLBACK_OBJS = fallback.o \
 		globals.o \
 		hexdump.o \
 		sbat_data.o \
+		time.o \
 		tpm.o \
 		utils.o
 

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ OBJS	= shim.o \
 	  csv.o \
 	  dp.o \
 	  errlog.o \
+	  hexdump.o \
 	  httpboot.o \
 	  globals.o \
 	  load-options.o \
@@ -76,6 +77,7 @@ ORIG_SOURCES	= shim.c \
 		  csv.c \
 		  dp.c \
 		  errlog.c \
+		  hexdump.c \
 		  httpboot.c \
 		  globals.c \
 		  load-options.c \
@@ -99,6 +101,7 @@ MOK_OBJS = MokManager.o \
 	   dp.o \
 	   errlog.o \
 	   globals.o \
+	   hexdump.o \
 	   PasswordCrypt.o \
 	   sbat_data.o \
 	   utils.o \
@@ -112,6 +115,7 @@ ORIG_MOK_SOURCES = MokManager.c \
 FALLBACK_OBJS = fallback.o \
 		errlog.o \
 		globals.o \
+		hexdump.o \
 		sbat_data.o \
 		tpm.o \
 		utils.o

--- a/hexdump.c
+++ b/hexdump.c
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+#include "shim.h"
+#include "include/console.h"
+
+static inline unsigned long UNUSED
+prepare_hex(const void *data, size_t size, char *buf, unsigned int position)
+{
+	char hexchars[] = "0123456789abcdef";
+	int offset = 0;
+	unsigned long i;
+	unsigned long j;
+	unsigned long ret;
+
+	unsigned long before = (position % 16);
+	unsigned long after = (before+size >= 16) ? 0 : 16 - (before+size);
+
+	for (i = 0; i < before; i++) {
+		buf[offset++] = 'X';
+		buf[offset++] = 'X';
+		buf[offset++] = ' ';
+		if (i == 7)
+			buf[offset++] = ' ';
+	}
+	for (j = 0; j < 16 - after - before; j++) {
+		uint8_t d = ((uint8_t *)data)[j];
+		buf[offset++] = hexchars[(d & 0xf0) >> 4];
+		buf[offset++] = hexchars[(d & 0x0f)];
+		if (i+j != 15)
+			buf[offset++] = ' ';
+		if (i+j == 7)
+			buf[offset++] = ' ';
+	}
+	ret = 16 - after - before;
+	j += i;
+	for (i = 0; i < after; i++) {
+		buf[offset++] = 'X';
+		buf[offset++] = 'X';
+		if (i+j != 15)
+			buf[offset++] = ' ';
+		if (i+j == 7)
+			buf[offset++] = ' ';
+	}
+	buf[offset] = '\0';
+	return ret;
+}
+
+static inline void UNUSED
+prepare_text(const void *data, size_t size, char *buf, unsigned int position)
+{
+	int offset = 0;
+	unsigned long i;
+	unsigned long j;
+
+	unsigned long before = position % 16;
+	unsigned long after = (before+size > 16) ? 0 : 16 - (before+size);
+
+	if (size == 0) {
+		buf[0] = '\0';
+		return;
+	}
+	for (i = 0; i < before; i++)
+		buf[offset++] = 'X';
+	buf[offset++] = '|';
+	for (j = 0; j < 16 - after - before; j++) {
+		if (isprint(((uint8_t *)data)[j]))
+			buf[offset++] = ((uint8_t *)data)[j];
+		else
+			buf[offset++] = '.';
+	}
+	buf[offset++] = '|';
+	buf[offset] = '\0';
+}
+
+/*
+ * variadic hexdump formatted
+ * think of it as: printf("%s%s\n", vformat(fmt, ap), hexdump(data,size));
+ */
+static inline void UNUSED EFIAPI
+vhexdumpf(const char *file, int line, const char *func, const CHAR16 *const fmt,
+          const void *data, unsigned long size, size_t at, ms_va_list ap)
+{
+	unsigned long display_offset = at;
+	unsigned long offset = 0;
+
+	if (verbose == 0)
+		return;
+
+	if (!data) {
+		dprint(L"hexdump of a NULL pointer!\n");
+		return;
+	}
+	if (!size) {
+		dprint(L"hexdump of a 0 size region!\n");
+		return;
+	}
+
+	while (offset < size) {
+		char hexbuf[49];
+		char txtbuf[19];
+		unsigned long sz;
+
+		sz = prepare_hex(data+offset, size-offset, hexbuf,
+				 (unsigned long)data+offset);
+		if (sz == 0)
+			return;
+
+		prepare_text(data+offset, size-offset, txtbuf,
+			     (unsigned long)data+offset);
+		if (fmt && fmt[0] != 0)
+			vdprint_(fmt, file, line, func, ap);
+		dprint_(L"%a:%d:%a() %08lx  %a  %a\n", file, line, func, display_offset, hexbuf, txtbuf);
+
+		display_offset += sz;
+		offset += sz;
+	}
+}
+
+/*
+ * hexdump formatted
+ * think of it as: printf("%s%s", format(fmt, ...), hexdump(data,size)[lineN]);
+ */
+void EFIAPI
+hexdumpf(const char *file, int line, const char *func, const CHAR16 *const fmt,
+         const void *data, unsigned long size, size_t at, ...)
+{
+	ms_va_list ap;
+
+	ms_va_start(ap, at);
+	vhexdumpf(file, line, func, fmt, data, size, at, ap);
+	ms_va_end(ap);
+}
+
+void
+hexdump(const char *file, int line, const char *func, const void *data, unsigned long size)
+{
+	hexdumpf(file, line, func, L"", data, size, (intptr_t)data);
+}
+
+void
+hexdumpat(const char *file, int line, const char *func, const void *data, unsigned long size, size_t at)
+{
+	hexdumpf(file, line, func, L"", data, size, at);
+}
+
+// vim:fenc=utf-8:tw=75:noet

--- a/include/console.h
+++ b/include/console.h
@@ -99,8 +99,10 @@ extern UINT32 verbose;
 #define dprint_(fmt, ...) ({							\
 		UINTN __dprint_ret = 0;						\
 		log_debug_print((fmt), ##__VA_ARGS__);				\
-		if (verbose)							\
+		if (verbose) {							\
+			update_watchdog();					\
 			__dprint_ret = console_print((fmt), ##__VA_ARGS__);	\
+		}								\
 		__dprint_ret;							\
 	})
 #define dprint(fmt, ...)						\

--- a/include/console.h
+++ b/include/console.h
@@ -103,8 +103,8 @@ extern UINT32 verbose;
 			__dprint_ret = console_print((fmt), ##__VA_ARGS__);	\
 		__dprint_ret;							\
 	})
-#define dprint(fmt, ...)                                              \
-	dprint_(L"%a:%d:%a() " fmt, __FILE__, __LINE__ - 1, __func__, \
+#define dprint(fmt, ...)						\
+	dprint_(L"%a:%d:%a() " fmt, __FILE__, __LINE__, __func__,	\
 	        ##__VA_ARGS__)
 #else
 #define dprint_(...) ({ ; })

--- a/include/hexdump.h
+++ b/include/hexdump.h
@@ -1,150 +1,17 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#ifndef STATIC_HEXDUMP_H
-#define STATIC_HEXDUMP_H
+#pragma once
 
 #include "shim.h"
-#include "include/console.h"
 
-static inline unsigned long UNUSED
-prepare_hex(const void *data, size_t size, char *buf, unsigned int position)
-{
-	char hexchars[] = "0123456789abcdef";
-	int offset = 0;
-	unsigned long i;
-	unsigned long j;
-	unsigned long ret;
+extern void EFIAPI hexdumpf(const char *file, int line, const char *func,
+                            const CHAR16 *const fmt, const void *data,
+                            unsigned long size, size_t at, ...);
+extern void hexdump(const char *file, int line, const char *func,
+                    const void *data, unsigned long size);
 
-	unsigned long before = (position % 16);
-	unsigned long after = (before+size >= 16) ? 0 : 16 - (before+size);
-
-	for (i = 0; i < before; i++) {
-		buf[offset++] = 'X';
-		buf[offset++] = 'X';
-		buf[offset++] = ' ';
-		if (i == 7)
-			buf[offset++] = ' ';
-	}
-	for (j = 0; j < 16 - after - before; j++) {
-		uint8_t d = ((uint8_t *)data)[j];
-		buf[offset++] = hexchars[(d & 0xf0) >> 4];
-		buf[offset++] = hexchars[(d & 0x0f)];
-		if (i+j != 15)
-			buf[offset++] = ' ';
-		if (i+j == 7)
-			buf[offset++] = ' ';
-	}
-	ret = 16 - after - before;
-	j += i;
-	for (i = 0; i < after; i++) {
-		buf[offset++] = 'X';
-		buf[offset++] = 'X';
-		if (i+j != 15)
-			buf[offset++] = ' ';
-		if (i+j == 7)
-			buf[offset++] = ' ';
-	}
-	buf[offset] = '\0';
-	return ret;
-}
-
-static inline void UNUSED
-prepare_text(const void *data, size_t size, char *buf, unsigned int position)
-{
-	int offset = 0;
-	unsigned long i;
-	unsigned long j;
-
-	unsigned long before = position % 16;
-	unsigned long after = (before+size > 16) ? 0 : 16 - (before+size);
-
-	if (size == 0) {
-		buf[0] = '\0';
-		return;
-	}
-	for (i = 0; i < before; i++)
-		buf[offset++] = 'X';
-	buf[offset++] = '|';
-	for (j = 0; j < 16 - after - before; j++) {
-		if (isprint(((uint8_t *)data)[j]))
-			buf[offset++] = ((uint8_t *)data)[j];
-		else
-			buf[offset++] = '.';
-	}
-	buf[offset++] = '|';
-	buf[offset] = '\0';
-}
-
-/*
- * variadic hexdump formatted
- * think of it as: printf("%s%s\n", vformat(fmt, ap), hexdump(data,size));
- */
-static inline void UNUSED EFIAPI
-vhexdumpf(const char *file, int line, const char *func, const CHAR16 *const fmt,
-          const void *data, unsigned long size, size_t at, ms_va_list ap)
-{
-	unsigned long display_offset = at;
-	unsigned long offset = 0;
-
-	if (verbose == 0)
-		return;
-
-	if (!data) {
-		dprint(L"hexdump of a NULL pointer!\n");
-		return;
-	}
-	if (!size) {
-		dprint(L"hexdump of a 0 size region!\n");
-		return;
-	}
-
-	while (offset < size) {
-		char hexbuf[49];
-		char txtbuf[19];
-		unsigned long sz;
-
-		sz = prepare_hex(data+offset, size-offset, hexbuf,
-				 (unsigned long)data+offset);
-		if (sz == 0)
-			return;
-
-		prepare_text(data+offset, size-offset, txtbuf,
-			     (unsigned long)data+offset);
-		if (fmt && fmt[0] != 0)
-			vdprint_(fmt, file, line, func, ap);
-		dprint_(L"%a:%d:%a() %08lx  %a  %a\n", file, line, func, display_offset, hexbuf, txtbuf);
-
-		display_offset += sz;
-		offset += sz;
-	}
-}
-
-/*
- * hexdump formatted
- * think of it as: printf("%s%s", format(fmt, ...), hexdump(data,size)[lineN]);
- */
-static inline void UNUSED EFIAPI
-hexdumpf(const char *file, int line, const char *func, const CHAR16 *const fmt,
-         const void *data, unsigned long size, size_t at, ...)
-{
-	ms_va_list ap;
-
-	ms_va_start(ap, at);
-	vhexdumpf(file, line, func, fmt, data, size, at, ap);
-	ms_va_end(ap);
-}
-
-static inline void UNUSED
-hexdump(const char *file, int line, const char *func, const void *data, unsigned long size)
-{
-	hexdumpf(file, line, func, L"", data, size, (intptr_t)data);
-}
-
-static inline void UNUSED
-hexdumpat(const char *file, int line, const char *func, const void *data, unsigned long size, size_t at)
-{
-	hexdumpf(file, line, func, L"", data, size, at);
-}
+extern void hexdumpat(const char *file, int line, const char *func,
+                      const void *data, unsigned long size, size_t at);
 
 #if defined(SHIM_UNIT_TEST)
 #define LogHexDump(data, ...)
@@ -160,5 +27,4 @@ hexdumpat(const char *file, int line, const char *func, const void *data, unsign
 	hexdumpf(__FILE__, __LINE__ - 1, __func__, fmt, data, sz, at, ##__VA_ARGS__)
 #endif
 
-#endif /* STATIC_HEXDUMP_H */
 // vim:fenc=utf-8:tw=75:noet

--- a/include/time.h
+++ b/include/time.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/*
+ * time.h - timekeeping things
+ * Copyright Peter Jones <pjones@redhat.com>
+ */
+
+#pragma once
+
+// vim:fenc=utf-8:tw=75:noet

--- a/include/time.h
+++ b/include/time.h
@@ -6,4 +6,18 @@
 
 #pragma once
 
+/*
+ * If we're building unit tests, then all of the structs for time will come
+ * from glibc, and all of these helpers are in libefivar.
+ */
+#ifndef SHIM_UNIT_TEST
+#include "Cryptlib/Include/CrtLibTime.h"
+
+extern int efi_time_to_tm(const EFI_TIME * const s, struct tm *d);
+extern int tm_to_efi_time(const struct tm *const s, EFI_TIME *d, bool tzadj);
+extern EFI_TIME *efi_gmtime_r(const time_t *time, EFI_TIME *result);
+extern EFI_TIME *efi_gmtime(const time_t *time);
+extern time_t efi_mktime(const EFI_TIME * const time);
+#endif
+
 // vim:fenc=utf-8:tw=75:noet

--- a/include/time.h
+++ b/include/time.h
@@ -20,4 +20,6 @@ extern EFI_TIME *efi_gmtime(const time_t *time);
 extern time_t efi_mktime(const EFI_TIME * const time);
 #endif
 
+extern void update_watchdog(void);
+
 // vim:fenc=utf-8:tw=75:noet

--- a/shim.c
+++ b/shim.c
@@ -1185,6 +1185,7 @@ efi_main (EFI_HANDLE passed_image_handle, EFI_SYSTEM_TABLE *passed_systab)
 	 */
 	InitializeLib(image_handle, systab);
 	setup_verbosity();
+	update_watchdog();
 
 	dprint(L"vendor_authorized:0x%08lx vendor_authorized_size:%lu\n",
 	       vendor_authorized, vendor_authorized_size);

--- a/shim.h
+++ b/shim.h
@@ -189,6 +189,7 @@
 #endif
 #include "include/simple_file.h"
 #include "include/str.h"
+#include "include/time.h"
 #include "include/tpm.h"
 #include "include/utils.h"
 #include "include/cc.h"

--- a/time.c
+++ b/time.c
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+/*
+ * time.c - timekeeping things
+ * Copyright Peter Jones <pjones@redhat.com>
+ */
+
+#include "shim.h"
+
+// vim:fenc=utf-8:tw=75:noet

--- a/time.c
+++ b/time.c
@@ -116,4 +116,37 @@ efi_mktime(const EFI_TIME * const time)
 	return ret;
 }
 
+#define TIMEOUT_SLOP	60
+#define TIMEOUT		(TIMEOUT_SLOP * 5)
+
+void
+update_watchdog(void)
+{
+	EFI_STATUS efi_status;
+	EFI_TIME efi_time = { 0, };
+	EFI_TIME_CAPABILITIES efi_time_caps = { 0, };
+	time_t this_time = 0;
+	static time_t last_time = 0;
+
+	efi_status = RT->GetTime(&efi_time, &efi_time_caps);
+	if (EFI_ERROR(efi_status)) {
+		BS->SetWatchdogTimer(TIMEOUT, 0x31337, 0, NULL);
+		return;
+	}
+
+	this_time = efi_mktime(&efi_time);
+	if (this_time < last_time ||
+	    this_time < TIMEOUT_SLOP ||
+	    this_time - TIMEOUT_SLOP > last_time) {
+		if (verbose) {
+			log_debug_print(L"updating watchdog at %llu from %llu to %llu\n",
+					this_time, last_time+TIMEOUT, this_time+TIMEOUT);
+			console_print(L"updating watchdog at %llu from %llu to %llu\n",
+				      this_time, last_time+TIMEOUT, this_time+TIMEOUT);
+		}
+		last_time = this_time;
+		BS->SetWatchdogTimer(TIMEOUT, 0x31337, 0, NULL);
+	}
+}
+
 // vim:fenc=utf-8:tw=75:noet

--- a/time.c
+++ b/time.c
@@ -6,4 +6,114 @@
 
 #include "shim.h"
 
+int
+efi_time_to_tm(const EFI_TIME * const s, struct tm *d)
+{
+	if (!s || !d) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	/*
+	 * This seems wrong but it works with what's currently in
+	 * TimerWrapper.c.  Specifically I think Year should subtract 1900
+	 * and Month should subtract 1 here to match difference between the
+	 * EFI spec and posix.
+	 */
+	d->tm_year = s->Year;
+	d->tm_mon = s->Month;
+	d->tm_mday = s->Day;
+	d->tm_hour = s->Hour;
+	d->tm_min = s->Minute;
+	/*
+           * Just ignore EFI's range problem here and pretend we're in UTC
+           * not UT1.
+           */
+	d->tm_sec = s->Second;
+	d->tm_isdst = (s->Daylight & EFI_TIME_IN_DAYLIGHT) ? 1 : 0;
+
+	return 0;
+}
+
+int
+tm_to_efi_time(const struct tm *const s, EFI_TIME *d, bool tzadj)
+{
+	if (!s || !d) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	d->Pad2 = 0;
+	d->Daylight = s->tm_isdst ? EFI_TIME_IN_DAYLIGHT : 0;
+	d->TimeZone = 0;
+	d->Nanosecond = 0;
+	d->Pad1 = 0;
+	d->Second = s->tm_sec < 60 ? s->tm_sec : 59;
+	d->Minute = s->tm_min;
+	d->Hour = s->tm_hour;
+	d->Day = s->tm_mday;
+	/*
+	 * This seems wrong but it works with what's currently in
+	 * TimerWrapper.c.  Specifically I think Year should add 1900
+	 * and Month should add 1 here to match difference between the
+	 * EFI spec and posix.
+	 */
+	d->Month = s->tm_mon;
+	d->Year = s->tm_year;
+
+	if (tzadj) {
+		d->TimeZone = timezone / 60;
+	}
+
+	return 0;
+}
+
+EFI_TIME *
+efi_gmtime_r(const time_t *time, EFI_TIME *result)
+{
+	struct tm tm = { 0, };
+
+	if (!time || !result) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	gmtime_r(time, &tm);
+	tm_to_efi_time(&tm, result, false);
+
+	return result;
+}
+
+EFI_TIME *
+efi_gmtime(const time_t *time)
+{
+	static EFI_TIME ret;
+
+	if (!time) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	efi_gmtime_r(time, &ret);
+
+	return &ret;
+}
+
+time_t
+efi_mktime(const EFI_TIME * const time)
+{
+	struct tm tm = { 0, };
+	time_t ret;
+
+	if (!time) {
+		errno = EINVAL;
+		return (time_t)-1;
+	}
+
+	efi_time_to_tm(time, &tm);
+	ret = mktime(&tm);
+
+	return ret;
+}
+
 // vim:fenc=utf-8:tw=75:noet


### PR DESCRIPTION
Two different people recently mentioned to me that they'd set SHIM_VERBOSE and soft-bricked their devices because the console was too slow and it eventually tripped the watchdog.

This patch series adds code to console_print() and related routines such that when we are in verbose mode and thus printing to the console, on each print call, if we have not updated the watchdog in the last minute, we will set the watchdog to go off in 5 minutes.

This way we're not updating it very often but we are giving ourselves *plenty* of time to do whatever we're doing, and if the watchdog does legitimately need to fire it still will, eventually.