### PR TITLE
Fix gnu-efi build directory

### DIFF
--- a/Make.defaults
+++ b/Make.defaults
@@ -160,8 +160,8 @@ endif
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --output-target efi-app-$(ARCH)
-LOCAL_EFI_PATH	= $(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/gnuefi
-LIBDIR		= $(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/lib
+LOCAL_EFI_PATH	= gnu-efi/$(ARCH_GNUEFI)/gnuefi
+LIBDIR		= gnu-efi/$(ARCH_GNUEFI)/lib
 
 MMSTEM		?= mm$(ARCH_SUFFIX)
 MMNAME		= $(MMSTEM).efi
@@ -192,7 +192,7 @@ ifneq ($(origin SBAT_AUTOMATIC_DATE), undefined)
 DEFINES		+= -DSBAT_AUTOMATIC_DATE=$(SBAT_AUTOMATIC_DATE)
 endif
 
-LDFLAGS		= --hash-style=sysv -nostdlib -znocombreloc -T $(EFI_LDS) -shared -Bsymbolic -L$(LIBDIR) -L$(LOCAL_EFI_PATH) -LCryptlib -LCryptlib/OpenSSL $(EFI_CRT_OBJS) --build-id=sha1 $(ARCH_LDFLAGS) --no-undefined
+LDFLAGS		= --hash-style=sysv -nostdlib -znocombreloc -T $(EFI_LDS) -shared -Bsymbolic -L$(LOCAL_EFI_PATH) -L$(LIBDIR) -LCryptlib -LCryptlib/OpenSSL $(EFI_CRT_OBJS) --build-id=sha1 $(ARCH_LDFLAGS) --no-undefined
 
 ifneq ($(DEBUG),)
 export DEBUG

--- a/Make.defaults
+++ b/Make.defaults
@@ -160,8 +160,8 @@ endif
 LIB_GCC		= $(shell $(CC) $(ARCH_CFLAGS) -print-libgcc-file-name)
 EFI_LIBS	= -lefi -lgnuefi --start-group Cryptlib/libcryptlib.a Cryptlib/OpenSSL/libopenssl.a --end-group $(LIB_GCC)
 FORMAT		?= --output-target efi-app-$(ARCH)
-LOCAL_EFI_PATH	= gnu-efi/$(ARCH_GNUEFI)/gnuefi
-LIBDIR		= gnu-efi/$(ARCH_GNUEFI)/lib
+LOCAL_EFI_PATH	= gnu-efi/gnuefi
+LIBDIR		= gnu-efi/lib
 
 MMSTEM		?= mm$(ARCH_SUFFIX)
 MMNAME		= $(MMSTEM).efi

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,8 @@ $(SHIMNAME) $(MMNAME) $(FBNAME) : | post-process-pe
 LIBS = Cryptlib/libcryptlib.a \
        Cryptlib/OpenSSL/libopenssl.a \
        lib/lib.a \
-       gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a \
-       gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a
+       gnu-efi/lib/libefi.a \
+       gnu-efi/gnuefi/libgnuefi.a
 
 $(SHIMSONAME): $(OBJS) $(LIBS)
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS) lib/lib.a
@@ -247,7 +247,7 @@ MokManager.o: $(MOK_SOURCES)
 $(MMSONAME): $(MOK_OBJS) $(LIBS)
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS) lib/lib.a
 
-gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a:
+gnu-efi/gnuefi/libgnuefi.a gnu-efi/lib/libefi.a:
 	mkdir -p gnu-efi/lib gnu-efi/gnuefi
 	$(MAKE) -C gnu-efi \
 		COMPILER="$(COMPILER)" \
@@ -256,6 +256,8 @@ gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a:
 		ARCH=$(ARCH_GNUEFI) \
 		NO_GLIBC=1 \
 		TOPDIR=$(TOPDIR)/gnu-efi \
+		VPATH=$(TOPDIR)/gnu-efi \
+		OBJDIR=. \
 		-f $(TOPDIR)/gnu-efi/Makefile \
 		lib gnuefi inc $(IGNORE_COMPILER_ERRORS)
 
@@ -508,6 +510,8 @@ clean-gnu-efi:
 			COMPILER="$(COMPILER)" \
 			ARCH=$(ARCH_GNUEFI) \
 			TOPDIR=$(TOPDIR)/gnu-efi \
+			VPATH=$(TOPDIR)/gnu-efi \
+			OBJDIR=. \
 			-f $(TOPDIR)/gnu-efi/Makefile \
 			clean ; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -231,8 +231,8 @@ $(SHIMNAME) $(MMNAME) $(FBNAME) : | post-process-pe
 LIBS = Cryptlib/libcryptlib.a \
        Cryptlib/OpenSSL/libopenssl.a \
        lib/lib.a \
-       $(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a \
-       $(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a
+       gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a \
+       gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a
 
 $(SHIMSONAME): $(OBJS) $(LIBS)
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS) lib/lib.a
@@ -247,7 +247,7 @@ MokManager.o: $(MOK_SOURCES)
 $(MMSONAME): $(MOK_OBJS) $(LIBS)
 	$(LD) -o $@ $(LDFLAGS) $^ $(EFI_LIBS) lib/lib.a
 
-$(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a $(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a:
+gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a gnu-efi/$(ARCH_GNUEFI)/lib/libefi.a:
 	mkdir -p gnu-efi/lib gnu-efi/gnuefi
 	$(MAKE) -C gnu-efi \
 		COMPILER="$(COMPILER)" \
@@ -256,7 +256,6 @@ $(TOPDIR)/gnu-efi/$(ARCH_GNUEFI)/gnuefi/libgnuefi.a $(TOPDIR)/gnu-efi/$(ARCH_GNU
 		ARCH=$(ARCH_GNUEFI) \
 		NO_GLIBC=1 \
 		TOPDIR=$(TOPDIR)/gnu-efi \
-		VPATH=$(TOPDIR)/gnu-efi \
 		-f $(TOPDIR)/gnu-efi/Makefile \
 		lib gnuefi inc $(IGNORE_COMPILER_ERRORS)
 
@@ -509,7 +508,6 @@ clean-gnu-efi:
 			COMPILER="$(COMPILER)" \
 			ARCH=$(ARCH_GNUEFI) \
 			TOPDIR=$(TOPDIR)/gnu-efi \
-			VPATH=$(TOPDIR)/gnu-efi \
 			-f $(TOPDIR)/gnu-efi/Makefile \
 			clean ; \
 	fi


### PR DESCRIPTION
An issue was spotted where, after merging #777, gnu-efi is now getting built inside the source directory (`$(TOPDIR)/gnu-efi`) instead of the build directory used for shim, as was the case in the past and should be the case in order to keep things nice and tidy. This PR addresses the issue.

Based on top of #778 to ensure full coverage (including riscv64), but can be rebased to remove the dependency.