### PR TITLE
fuzz: merge profiles from parallel fuzzer workers

### DIFF
--- a/include/fuzz.mk
+++ b/include/fuzz.mk
@@ -11,6 +11,7 @@ CC = clang
 DEBUG_PRINTS ?= 0
 OPTIMIZATIONS ?= -Og -ggdb
 FUZZ_ARGS ?=
+LLVM_PROFDATA ?= $(shell $(CC) -print-prog-name=llvm-profdata)
 MAX_FUZZ_TIME ?=
 CFLAGS = $(OPTIMIZATIONS) -std=gnu11 \
 	 -isystem $(TOPDIR)/include/system \
@@ -102,12 +103,15 @@ endif
 $(fuzzers) :: fuzz-% : test.c fuzz-%.c $(fuzz-%_FILES)
 	$(CC) $(CFLAGS) -o $@ $(sort $^ $(wildcard $*.c) $(fuzz-$*_FILES)) libefi-test.a -lefivar
 	mkdir -p $@-corpus
-	cd $@-corpus ; LLVM_PROFILE_FILE="$@.profraw" ../$@ \
+	rm -f $@-corpus/$@.profdata $@-corpus/$@*.profraw
+	cd $@-corpus ; LLVM_PROFILE_FILE="$@.%p.profraw" ../$@ \
 		-jobs=24 \
 		-max_len=4096 \
 		$(MAX_TOTAL_TIME) \
 		$(FUZZ_ARGS) \
 		../$@-corpus
+	cd $@-corpus ; $(LLVM_PROFDATA) merge -sparse $@.*.profraw -o $@.profdata
+	rm -f $@-corpus/$@.*.profraw
 
 fuzz : $(fuzzers)
 	$(MAKE) -f include/fuzz.mk fuzz-clean


### PR DESCRIPTION
The fuzzers run up to 24 workers, but all workers currently write to one `.profraw` file. Their exit-time writes can overwrite or race with each other, making direct fuzz-run coverage data unreliable.

Write one raw profile per worker using LLVM's `%p` expansion, merge the shards with the `llvm-profdata` matching the selected compiler, then remove the raw shards after a successful merge.

Validated with a `fuzz-tftpboot` run: `llvm-cov report` successfully consumed the merged profile. `cov-analysis` continues to work as well.